### PR TITLE
MP-170 ♲ Removed unit attribute from pudo locations

### DIFF
--- a/src/Resources/Position.php
+++ b/src/Resources/Position.php
@@ -13,7 +13,6 @@ class Position implements PositionInterface
     private $latitude;
     private $longitude;
     private $distance;
-    private $unit = self::UNIT_METER;
 
     private static $unitConversion = [
         self::UNIT_METER     => 1,

--- a/tests/Feature/ResourceFactoryTest.php
+++ b/tests/Feature/ResourceFactoryTest.php
@@ -229,7 +229,6 @@ class ResourceFactoryTest extends TestCase
                 'latitude'  => 1.2345,
                 'longitude' => 2.34567,
                 'distance'  => 5000,
-                'unit'      => 'meters',
             ],
         ];
 

--- a/tests/Stubs/get/https---api-v1-carriers-eef00b32-177e-43d3-9b26-715365e4ce46-pickup-dropoff-locations-GB-B48 7QN.json
+++ b/tests/Stubs/get/https---api-v1-carriers-eef00b32-177e-43d3-9b26-715365e4ce46-pickup-dropoff-locations-GB-B48 7QN.json
@@ -54,8 +54,7 @@
         "position": {
           "latitude": 52.3032936742545,
           "longitude": 4.69476214016944,
-          "distance": 318,
-          "unit": "meters"
+          "distance": 318
         }
       },
       "relationships": {
@@ -124,8 +123,7 @@
         "position": {
           "latitude": 52.3089878674629,
           "longitude": 4.68188672729443,
-          "distance": 764,
-          "unit": "meters"
+          "distance": 764
         }
       },
       "relationships": {
@@ -195,8 +193,7 @@
         "position": {
           "latitude": 52.3143764678125,
           "longitude": 4.69640792135398,
-          "distance": 1137,
-          "unit": "meters"
+          "distance": 1137
         }
       },
       "relationships": {
@@ -266,8 +263,7 @@
         "position": {
           "latitude": 52.3155020752417,
           "longitude": 4.69523182366827,
-          "distance": 1233,
-          "unit": "meters"
+          "distance": 1233
         }
       },
       "relationships": {
@@ -336,8 +332,7 @@
         "position": {
           "latitude": 52.3094281618872,
           "longitude": 4.67139513180198,
-          "distance": 1413,
-          "unit": "meters"
+          "distance": 1413
         }
       },
       "relationships": {
@@ -406,8 +401,7 @@
         "position": {
           "latitude": 52.3013913423774,
           "longitude": 4.66375416731004,
-          "distance": 1872,
-          "unit": "meters"
+          "distance": 1872
         }
       },
       "relationships": {
@@ -476,8 +470,7 @@
         "position": {
           "latitude": 52.2864669620795,
           "longitude": 4.68239055845954,
-          "distance": 2110,
-          "unit": "meters"
+          "distance": 2110
         }
       },
       "relationships": {
@@ -546,8 +539,7 @@
         "position": {
           "latitude": 52.3147095499762,
           "longitude": 4.65903497807609,
-          "distance": 2422,
-          "unit": "meters"
+          "distance": 2422
         }
       },
       "relationships": {
@@ -616,8 +608,7 @@
         "position": {
           "latitude": 52.3066891744711,
           "longitude": 4.63838904899413,
-          "distance": 3565,
-          "unit": "meters"
+          "distance": 3565
         }
       },
       "relationships": {
@@ -686,8 +677,7 @@
         "position": {
           "latitude": 52.3569768014508,
           "longitude": 5.15416255988611,
-          "distance": 32019,
-          "unit": "meters"
+          "distance": 32019
         }
       },
       "relationships": {

--- a/tests/Unit/PickUpDropOffLocationTest.php
+++ b/tests/Unit/PickUpDropOffLocationTest.php
@@ -123,7 +123,6 @@ class PickUpDropOffLocationTest extends TestCase
                 'latitude'  => 1.2345,
                 'longitude' => 2.34567,
                 'distance'  => 5000,
-                'unit'      => 'meters',
             ]);
 
         $pudoLocation = (new PickUpDropOffLocation())
@@ -162,7 +161,6 @@ class PickUpDropOffLocationTest extends TestCase
                     'latitude'  => 1.2345,
                     'longitude' => 2.34567,
                     'distance'  => 5000,
-                    'unit'      => 'meters',
                 ],
             ],
         ], $pudoLocation->jsonSerialize());

--- a/tests/Unit/PositionTest.php
+++ b/tests/Unit/PositionTest.php
@@ -68,7 +68,6 @@ class PositionTest extends TestCase
             'latitude'  => 2.56784948,
             'longitude' => 1.123465498,
             'distance'  => 900,
-            'unit'      => 'meters',
         ], $position->jsonSerialize());
     }
 }


### PR DESCRIPTION
The SDK never exposed units to the user as a property of location, but always converted to and from meters.