### PR TITLE
🐛 When retrieving regions with a region code, fallback to regions wit…

### DIFF
--- a/src/MyParcelComApi.php
+++ b/src/MyParcelComApi.php
@@ -137,6 +137,15 @@ class MyParcelComApi implements MyParcelComApiInterface
         }
 
         // These resources can be stored for a week.
+        $regions = $this->getResourceCollection($url->getUrl(), self::TTL_WEEK);
+
+        if ($regions->count() > 0 || $regionCode === null) {
+            return $regions;
+        }
+
+        // Fallback to the country if the specific region is not in the API.
+        $url->addQuery(['filter[region_code]' => null]);
+
         return $this->getResourceCollection($url->getUrl(), self::TTL_WEEK);
     }
 

--- a/tests/Feature/MyParcelComApiTest.php
+++ b/tests/Feature/MyParcelComApiTest.php
@@ -6,7 +6,6 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use MyParcelCom\ApiSdk\Authentication\AuthenticatorInterface;
 use MyParcelCom\ApiSdk\Collection\CollectionInterface;
-use MyParcelCom\ApiSdk\Collection\PromiseCollection;
 use MyParcelCom\ApiSdk\Exceptions\InvalidResourceException;
 use MyParcelCom\ApiSdk\MyParcelComApi;
 use MyParcelCom\ApiSdk\Resources\Address;
@@ -336,6 +335,19 @@ class MyParcelComApiTest extends TestCase
             $this->assertInstanceOf(RegionInterface::class, $region);
             $this->assertEquals('GB', $region->getCountryCode());
             $this->assertEquals('NIR', $region->getRegionCode());
+        }
+    }
+
+    /** @test */
+    public function testGetRegionsWithNonExistingRegionCode()
+    {
+        $regions = $this->api->getRegions('NL', 'NH');
+
+        $this->assertInstanceOf(CollectionInterface::class, $regions);
+        $this->assertEquals(1, $regions->count());
+        foreach ($regions as $region) {
+            $this->assertInstanceOf(RegionInterface::class, $region);
+            $this->assertEquals('NL', $region->getCountryCode());
         }
     }
 

--- a/tests/Stubs/get/https---api-v1-regions-filter-country_code--NL-filter-region_code--NH-page-number--1-page-size--30.json
+++ b/tests/Stubs/get/https---api-v1-regions-filter-country_code--NL-filter-region_code--NH-page-number--1-page-size--30.json
@@ -1,0 +1,12 @@
+{
+  "data": [],
+  "meta": {
+    "total_pages": 1,
+    "total_records": 0
+  },
+  "links": {
+    "self": "https://api/v1/regions?filter[country_code]=NL&filter[region_code]=NH&page[size]=30&page[number]=1",
+    "first": "https://api/v1/regions?filter[country_code]=NL&filter[region_code]=NH&page[size]=30&page[number]=1",
+    "last": "https://api/v1/regions?filter[country_code]=NL&filter[region_code]=NH&page[size]=30&page[number]=1"
+  }
+}

--- a/tests/Stubs/get/https---api-v1-regions-filter-country_code--NL-page-number--1-page-size--30.json
+++ b/tests/Stubs/get/https---api-v1-regions-filter-country_code--NL-page-number--1-page-size--30.json
@@ -1,0 +1,36 @@
+{
+  "data": [
+    {
+      "id": "9bc528b0-93df-4522-964c-06abd17a3de1",
+      "type": "regions",
+      "attributes": {
+        "name": "Netherlands",
+        "country_code": "NL",
+        "currency": "EUR"
+      },
+      "links": {
+        "self": "https://api/v1/regions/9bc528b0-93df-4522-964c-06abd17a3de1"
+      },
+      "relationships": {
+        "parent": {
+          "data": {
+            "id": "bb428358-b176-43a1-adda-a43349e11665",
+            "type": "regions"
+          },
+          "links": {
+            "related": "https://api/v1/regions/bb428358-b176-43a1-adda-a43349e11665"
+          }
+        }
+      }
+    }
+  ],
+  "meta": {
+    "total_pages": 1,
+    "total_records": 1
+  },
+  "links": {
+    "self": "https://api/v1/regions?filter[country_code]=NL&page[size]=30&page[number]=1",
+    "first": "https://api/v1/regions?filter[country_code]=NL&page[size]=30&page[number]=1",
+    "last": "https://api/v1/regions?filter[country_code]=NL&page[size]=30&page[number]=1"
+  }
+}


### PR DESCRIPTION
…hout that region code when none can be found.