### PR TITLE
Add postal code filter to get regions

### DIFF
--- a/src/MyParcelComApi.php
+++ b/src/MyParcelComApi.php
@@ -133,7 +133,7 @@ class MyParcelComApi implements MyParcelComApiInterface
     /**
      * {@inheritdoc}
      */
-    public function getRegions($filters = null)
+    public function getRegions($filters = [])
     {
         $url = (new UrlBuilder($this->apiUri . self::PATH_REGIONS));
 

--- a/src/MyParcelComApi.php
+++ b/src/MyParcelComApi.php
@@ -136,31 +136,30 @@ class MyParcelComApi implements MyParcelComApiInterface
     public function getRegions($filters = null)
     {
         $url = (new UrlBuilder($this->apiUri . self::PATH_REGIONS));
-        $queryParams = [];
-
-        $functionArguments = func_get_args();
 
         // This method used to accept a $countryCode as the first argument and
         // a $regionCode as the second argument. We converted it to accept just
         // a $filters argument, but the logic below ensures backward compatibility.
-        if (is_array($filters)) {
-            foreach ($filters as $key => $value) {
-                $queryParams['filter[' . $key . ']'] = $value;
-            }
-        } elseif (count($functionArguments) > 0 && !is_array($functionArguments[0])) {
-            $queryParams['filter[country_code]'] = $functionArguments[0];
+        $functionArguments = func_get_args();
+        if (count($functionArguments) > 0 && !is_array($functionArguments[0])) {
+            $filters = [];
+            $filters['country_code'] = $functionArguments[0];
 
             if (isset($functionArguments[1])) {
-                $queryParams['filter[region_code]'] = $functionArguments[1];
+                $filters['region_code'] = $functionArguments[1];
             }
         }
 
-        $url->addQuery($queryParams);
+        if (is_array($filters)) {
+            foreach ($filters as $key => $value) {
+                $url->addQuery(['filter[' . $key . ']' => $value]);
+            }
+        }
 
         // These resources can be stored for a week.
         $regions = $this->getRequestCollection($url->getUrl(), self::TTL_WEEK);
 
-        if ($regions->count() > 0 || !isset($queryParams['filter[region_code]'])) {
+        if ($regions->count() > 0 || !isset($filters['region_code'])) {
             return $regions;
         }
 

--- a/src/MyParcelComApiInterface.php
+++ b/src/MyParcelComApiInterface.php
@@ -38,13 +38,19 @@ interface MyParcelComApiInterface
     public function authenticate(AuthenticatorInterface $authenticator);
 
     /**
-     * Get an array with all the regions, optionally regions can be filtered by
-     * country code and region code.
+     * Get an array with all the regions. An array of
+     * filters can be provided to limit the results to
+     * a subset. Available filters:
+     * - country_code
+     * - region_code
+     * - postal_code
      *
-     * @param mixed $filters
+     * @see https://docs.myparcel.com/api/resources/regions/#parameters
+     *
+     * @param array $filters
      * @return CollectionInterface
      */
-    public function getRegions($filters = null);
+    public function getRegions($filters = []);
 
     /**
      * Get all the carriers from the API.

--- a/src/MyParcelComApiInterface.php
+++ b/src/MyParcelComApiInterface.php
@@ -41,11 +41,10 @@ interface MyParcelComApiInterface
      * Get an array with all the regions, optionally regions can be filtered by
      * country code and region code.
      *
-     * @param string|null $countryCode
-     * @param string|null $regionCode
+     * @param mixed $filters
      * @return CollectionInterface
      */
-    public function getRegions($countryCode = null, $regionCode = null);
+    public function getRegions($filters = null);
 
     /**
      * Get all the carriers from the API.

--- a/tests/Feature/MyParcelComApiTest.php
+++ b/tests/Feature/MyParcelComApiTest.php
@@ -402,6 +402,34 @@ class MyParcelComApiTest extends TestCase
     /** @test */
     public function testGetGbRegions()
     {
+        $regions = $this->api->getRegions([
+            'country_code' => 'GB',
+        ]);
+
+        $this->assertInstanceOf(CollectionInterface::class, $regions);
+        $this->assertEquals(9, $regions->count());
+        foreach ($regions as $region) {
+            $this->assertInstanceOf(RegionInterface::class, $region);
+            $this->assertEquals('GB', $region->getCountryCode());
+        }
+
+        $ireland = $this->api->getRegions([
+            'country_code' => 'GB',
+            'region_code'  => 'NIR',
+        ]);
+
+        $this->assertInstanceOf(CollectionInterface::class, $ireland);
+        $this->assertEquals(1, $ireland->count());
+        foreach ($ireland as $region) {
+            $this->assertInstanceOf(RegionInterface::class, $region);
+            $this->assertEquals('GB', $region->getCountryCode());
+            $this->assertEquals('NIR', $region->getRegionCode());
+        }
+    }
+
+    /** @test */
+    public function testGetGbRegionsWithBackwardCompatibility()
+    {
         $regions = $this->api->getRegions('GB');
 
         $this->assertInstanceOf(CollectionInterface::class, $regions);
@@ -424,6 +452,22 @@ class MyParcelComApiTest extends TestCase
 
     /** @test */
     public function testGetRegionsWithNonExistingRegionCode()
+    {
+        $regions = $this->api->getRegions([
+            'country_code' => 'NL',
+            'region_code'  => 'NH',
+        ]);
+
+        $this->assertInstanceOf(CollectionInterface::class, $regions);
+        $this->assertEquals(1, $regions->count());
+        foreach ($regions as $region) {
+            $this->assertInstanceOf(RegionInterface::class, $region);
+            $this->assertEquals('NL', $region->getCountryCode());
+        }
+    }
+
+    /** @test */
+    public function testGetRegionsWithNonExistingRegionCodeWithBackwardCompatibility()
     {
         $regions = $this->api->getRegions('NL', 'NH');
 

--- a/tests/Feature/MyParcelComApiTest.php
+++ b/tests/Feature/MyParcelComApiTest.php
@@ -480,6 +480,22 @@ class MyParcelComApiTest extends TestCase
     }
 
     /** @test */
+    public function testItFiltersRegionsByPostalCode()
+    {
+        $regions = $this->api->getRegions([
+            'country_code' => 'GB',
+            'postal_code'  => 'NW1 6XE',
+        ]);
+
+        $this->assertInstanceOf(CollectionInterface::class, $regions);
+        $this->assertEquals(1, $regions->count());
+        foreach ($regions as $region) {
+            $this->assertInstanceOf(RegionInterface::class, $region);
+            $this->assertEquals('GB', $region->getCountryCode());
+        }
+    }
+
+    /** @test */
     public function testGetServices()
     {
         $services = $this->api->getServices();

--- a/tests/Stubs/get/https---api-regions/filter-country_code--GB/filter-postal_code--NW1 6XE/page-number--1/page-size--30.json
+++ b/tests/Stubs/get/https---api-regions/filter-country_code--GB/filter-postal_code--NW1 6XE/page-number--1/page-size--30.json
@@ -1,0 +1,37 @@
+{
+  "data": [
+    {
+      "id": "59f129d1-23fa-427e-b0d3-50a498a99044",
+      "type": "regions",
+      "attributes": {
+        "name": "England",
+        "country_code": "GB",
+        "region_code": "ENG",
+        "currency": "GBP"
+      },
+      "links": {
+        "self": "https://api/regions/59f129d1-23fa-427e-b0d3-50a498a99044"
+      },
+      "relationships": {
+        "parent": {
+          "data": {
+            "id": "4e433f7b-96a7-4bcd-b0e2-d6ef7322bab2",
+            "type": "regions"
+          },
+          "links": {
+            "related": "https://api/regions/4e433f7b-96a7-4bcd-b0e2-d6ef7322bab2"
+          }
+        }
+      }
+    }
+  ],
+  "meta": {
+    "total_pages": 1,
+    "total_records": 1
+  },
+  "links": {
+    "self": "https://api/regions?filter[country_code]=GB&filter[postal_code]=NW1 6XE&page[size]=30&page[number]=1",
+    "first": "https://api/regions?filter[country_code]=GB&filter[postal_code]=NW1 6XE&page[size]=30&page[number]=1",
+    "last": "https://api/regions?filter[country_code]=GB&filter[postal_code]=NW1 6XE&page[size]=30&page[number]=1"
+  }
+}


### PR DESCRIPTION
**Changes**
- Changed `getRegions()` method signature to accept  only a `$filters` array
- Ensured backward compatibility of above changes
- Added test to ensure `postal_code` filter is correctly applied

**Related issues**
- https://myparcelcombv.atlassian.net/browse/MP-2112