### PR TITLE
MP-2457 add volumetric weight to sdk

### DIFF
--- a/src/MyParcelComApi.php
+++ b/src/MyParcelComApi.php
@@ -10,6 +10,7 @@ use MyParcelCom\ApiSdk\Collection\ArrayCollection;
 use MyParcelCom\ApiSdk\Collection\CollectionInterface;
 use MyParcelCom\ApiSdk\Collection\RequestCollection;
 use MyParcelCom\ApiSdk\Exceptions\InvalidResourceException;
+use MyParcelCom\ApiSdk\Exceptions\ResourceNotFoundException;
 use MyParcelCom\ApiSdk\Http\Contracts\HttpClient\RequestExceptionInterface;
 use MyParcelCom\ApiSdk\Http\Exceptions\RequestException;
 use MyParcelCom\ApiSdk\Resources\Interfaces\CarrierInterface;
@@ -349,6 +350,10 @@ class MyParcelComApi implements MyParcelComApiInterface
         $serviceIds = [];
         foreach ($services as $service) {
             $serviceIds[] = $service->getId();
+        }
+
+        if (empty($serviceIds)) {
+            return new ArrayCollection([]);
         }
 
         $url = new UrlBuilder($this->apiUri . self::PATH_SERVICE_RATES);

--- a/src/MyParcelComApi.php
+++ b/src/MyParcelComApi.php
@@ -354,6 +354,7 @@ class MyParcelComApi implements MyParcelComApiInterface
         $url = new UrlBuilder($this->apiUri . self::PATH_SERVICE_RATES);
         $url->addQuery([
             'filter[weight]'  => $shipment->getPhysicalProperties()->getWeight(),
+            'filter[volumetric_weight]' => $shipment->getPhysicalProperties()->getVolumetricWeight(),
             'filter[service]' => implode(',', $serviceIds),
         ]);
 
@@ -574,7 +575,7 @@ class MyParcelComApi implements MyParcelComApiInterface
     protected function getResourcesArray($uri, $ttl = self::TTL_10MIN)
     {
         $response = $this->doRequest($uri, 'get', [], [], $ttl);
-        $json = json_decode((string)$response->getBody(), true);
+        $json = json_decode((string) $response->getBody(), true);
 
         $resources = $this->jsonToResources($json['data']);
 
@@ -706,7 +707,7 @@ class MyParcelComApi implements MyParcelComApiInterface
 
         $request = $exception->getRequest();
 
-        $body = (string)$request->getBody();
+        $body = (string) $request->getBody();
         $jsonBody = $body
             ? json_decode($body, true)
             : [];
@@ -817,6 +818,7 @@ class MyParcelComApi implements MyParcelComApiInterface
     private function arrayToFilters(array $array)
     {
         $filters = [];
+
         $this->arrayToFilter($filters, ['filter'], $array);
 
         return $filters;

--- a/src/MyParcelComApi.php
+++ b/src/MyParcelComApi.php
@@ -352,11 +352,11 @@ class MyParcelComApi implements MyParcelComApiInterface
         }
 
         $url = new UrlBuilder($this->apiUri . self::PATH_SERVICE_RATES);
-        $url->addQuery([
-            'filter[weight]'  => $shipment->getPhysicalProperties()->getWeight(),
-            'filter[volumetric_weight]' => $shipment->getPhysicalProperties()->getVolumetricWeight(),
-            'filter[service]' => implode(',', $serviceIds),
-        ]);
+        $url->addQuery($this->arrayToFilters([
+            'weight'            => $shipment->getPhysicalProperties()->getWeight(),
+            'volumetric_weight' => $shipment->getPhysicalProperties()->getVolumetricWeight(),
+            'service'           => implode(',', $serviceIds),
+        ]));
 
         $serviceRates = $this->getRequestCollection($url->getUrl(), self::TTL_WEEK);
 

--- a/src/Resources/Interfaces/PhysicalPropertiesInterface.php
+++ b/src/Resources/Interfaces/PhysicalPropertiesInterface.php
@@ -68,7 +68,16 @@ interface PhysicalPropertiesInterface extends \JsonSerializable
     public function getVolume();
 
     /**
-     * @return null|int
+     * @param int $volumetricWeight
+     * @return $this
+     */
+    public function setVolumetricWeight($volumetricWeight);
+
+    /**
+     * Returns the volumetric weight if already set.
+     * Calculates the shipment's volumetric weight in grams based on set dimensions otherwise.
+     *
+     * @return null|int Returns null if not all dimensions are set.
      */
     public function getVolumetricWeight();
 }

--- a/src/Resources/Interfaces/PhysicalPropertiesInterface.php
+++ b/src/Resources/Interfaces/PhysicalPropertiesInterface.php
@@ -11,35 +11,35 @@ interface PhysicalPropertiesInterface extends \JsonSerializable
     const WEIGHT_STONE = 'stones';
 
     /**
-     * @param int $width
+     * @param null|int $width
      * @return $this
      */
     public function setWidth($width);
 
     /**
-     * @return int
+     * @return null|int
      */
     public function getWidth();
 
     /**
-     * @param int $height
+     * @param null|int $height
      * @return $this
      */
     public function setHeight($height);
 
     /**
-     * @return int
+     * @return null|int
      */
     public function getHeight();
 
     /**
-     * @param int $length
+     * @param null|int $length
      * @return $this
      */
     public function setLength($length);
 
     /**
-     * @return int
+     * @return null|int
      */
     public function getLength();
 
@@ -66,4 +66,9 @@ interface PhysicalPropertiesInterface extends \JsonSerializable
      * @return int
      */
     public function getVolume();
+
+    /**
+     * @return null|int
+     */
+    public function getVolumetricWeight();
 }

--- a/src/Resources/Interfaces/ShipmentInterface.php
+++ b/src/Resources/Interfaces/ShipmentInterface.php
@@ -134,19 +134,19 @@ interface ShipmentInterface extends ResourceInterface
     public function getTrackingUrl();
 
     /**
-     * @deprecated Use Shipment::getPhysicalProperties()->setWeight() instead.
-     *
      * @param int    $weight
      * @param string $unit
      * @return $this
+     * @deprecated Use Shipment::getPhysicalProperties()->setWeight() instead.
+     *
      */
     public function setWeight($weight, $unit = PhysicalPropertiesInterface::WEIGHT_GRAM);
 
     /**
-     * @deprecated Use Shipment::getPhysicalProperties()->getWeight() instead.
-     *
      * @param string $unit
      * @return int
+     * @deprecated Use Shipment::getPhysicalProperties()->getWeight() instead.
+     *
      */
     public function getWeight($unit = PhysicalPropertiesInterface::WEIGHT_GRAM);
 
@@ -188,6 +188,17 @@ interface ShipmentInterface extends ResourceInterface
      * @return PhysicalPropertiesInterface|null
      */
     public function getPhysicalProperties();
+
+    /**
+     * @return null|int
+     */
+    public function getVolumetricWeight();
+
+    /**
+     * @param int $volumetricWeight
+     * @return $this
+     */
+    public function setVolumetricWeight($volumetricWeight);
 
     /**
      * @param FileInterface[] $files

--- a/src/Resources/PhysicalProperties.php
+++ b/src/Resources/PhysicalProperties.php
@@ -25,6 +25,9 @@ class PhysicalProperties implements PhysicalPropertiesInterface
     /** @var int */
     private $width;
 
+    /** @var int */
+    private $volumetricWeight;
+
     /** @var array */
     private static $unitConversion = [
         self::WEIGHT_GRAM     => 1,
@@ -39,7 +42,7 @@ class PhysicalProperties implements PhysicalPropertiesInterface
      */
     public function setWidth($width)
     {
-        $this->width = (int)$width;
+        $this->width = (int) $width;
 
         return $this;
     }
@@ -57,7 +60,7 @@ class PhysicalProperties implements PhysicalPropertiesInterface
      */
     public function setHeight($height)
     {
-        $this->height = (int)$height;
+        $this->height = (int) $height;
 
         return $this;
     }
@@ -75,7 +78,7 @@ class PhysicalProperties implements PhysicalPropertiesInterface
      */
     public function setLength($length)
     {
-        $this->length = (int)$length;
+        $this->length = (int) $length;
 
         return $this;
     }
@@ -97,7 +100,7 @@ class PhysicalProperties implements PhysicalPropertiesInterface
             throw new MyParcelComException('invalid unit: ' . $unit);
         }
 
-        $this->weight = (int)round($weight * self::$unitConversion[$unit]);
+        $this->weight = (int) round($weight * self::$unitConversion[$unit]);
 
         return $this;
     }
@@ -111,7 +114,7 @@ class PhysicalProperties implements PhysicalPropertiesInterface
             throw new MyParcelComException('invalid unit: ' . $unit);
         }
 
-        return (int)round($this->weight / self::$unitConversion[$unit]);
+        return (int) round($this->weight / self::$unitConversion[$unit]);
     }
 
     /**
@@ -137,6 +140,6 @@ class PhysicalProperties implements PhysicalPropertiesInterface
      */
     public function getVolumetricWeight()
     {
-        // TODO: Implement getVolumetricWeight() method.
+        return $this->volumetricWeight;
     }
 }

--- a/src/Resources/PhysicalProperties.php
+++ b/src/Resources/PhysicalProperties.php
@@ -136,10 +136,28 @@ class PhysicalProperties implements PhysicalPropertiesInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function getVolumetricWeight()
     {
-        return $this->volumetricWeight;
+        if ($this->volumetricWeight) {
+            return $this->volumetricWeight;
+        }
+
+        if (!$this->length || !$this->width || !$this->height) {
+            return null;
+        }
+
+        return (int) ceil($this->length * $this->width * $this->height / 5000);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setVolumetricWeight($volumetricWeight)
+    {
+        $this->volumetricWeight = $volumetricWeight;
+
+        return $this;
     }
 }

--- a/src/Resources/PhysicalProperties.php
+++ b/src/Resources/PhysicalProperties.php
@@ -131,4 +131,12 @@ class PhysicalProperties implements PhysicalPropertiesInterface
     {
         return $this->volume;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getVolumetricWeight()
+    {
+        // TODO: Implement getVolumetricWeight() method.
+    }
 }

--- a/src/Resources/Proxy/ShipmentProxy.php
+++ b/src/Resources/Proxy/ShipmentProxy.php
@@ -358,6 +358,25 @@ class ShipmentProxy implements ShipmentInterface, ResourceProxyInterface
     }
 
     /**
+     * @param int $volumetricWeight
+     * @return $this
+     */
+    public function setVolumetricWeight($volumetricWeight)
+    {
+        $this->getResource()->getPhysicalProperties()->setVolumetricWeight($volumetricWeight);
+
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getVolumetricWeight()
+    {
+        return $this->getResource()->getPhysicalProperties()->getVolumetricWeight();
+    }
+
+    /**
      * @param FileInterface[] $files
      * @return $this
      */

--- a/src/Resources/Shipment.php
+++ b/src/Resources/Shipment.php
@@ -381,6 +381,31 @@ class Shipment implements ShipmentInterface
     /**
      * {@inheritdoc}
      */
+    public function setVolumetricWeight($volumetricWeight)
+    {
+        if ($this->getPhysicalProperties() === null) {
+            $this->setPhysicalProperties(new PhysicalProperties());
+        }
+        $this->getPhysicalProperties()->setVolumetricWeight($volumetricWeight);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getVolumetricWeight()
+    {
+        if ($this->getPhysicalProperties() === null) {
+            $this->setPhysicalProperties(new PhysicalProperties());
+        }
+
+        return $this->getPhysicalProperties()->getVolumetricWeight();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function setShop(ShopInterface $shop)
     {
         $this->relationships[self::RELATIONSHIP_SHOP]['data'] = $shop;

--- a/src/Shipments/PriceCalculator.php
+++ b/src/Shipments/PriceCalculator.php
@@ -78,7 +78,7 @@ class PriceCalculator
             $price += $optionPrice;
         }
 
-        return (int)$price;
+        return (int) $price;
     }
 
     /**
@@ -116,8 +116,9 @@ class PriceCalculator
         $this->validateShipment($shipment);
 
         $serviceRates = $shipment->getService()->getServiceRates([
-            'contract' => $shipment->getContract(),
-            'weight'   => $shipment->getPhysicalProperties()->getWeight(),
+            'contract'          => $shipment->getContract(),
+            'weight'            => $shipment->getPhysicalProperties()->getWeight(),
+            'volumetric_weight' => $shipment->getPhysicalProperties()->getVolumetricWeight(),
         ]);
 
         $shipmentOptionIds = array_map(function (ServiceOptionInterface $serviceOption) {

--- a/src/Shipments/ServiceMatcher.php
+++ b/src/Shipments/ServiceMatcher.php
@@ -19,9 +19,11 @@ class ServiceMatcher
      */
     public function matches(ShipmentInterface $shipment, ServiceInterface $service)
     {
-        if ($shipment->getPhysicalProperties() === null
+        if (
+            $shipment->getPhysicalProperties() === null
             || $shipment->getPhysicalProperties()->getWeight() === null
-            || $shipment->getPhysicalProperties()->getWeight() < 0) {
+            || $shipment->getPhysicalProperties()->getWeight() < 0
+        ) {
             throw new InvalidResourceException(
                 'Cannot match shipment and service without a valid shipment weight.'
             );
@@ -30,7 +32,8 @@ class ServiceMatcher
         // TODO: Add check for matching regions. We need to implement ancestor regions in the SDK in order to do this.
         return $this->matchesDeliveryMethod($shipment, $service)
             && ($serviceRates = $service->getServiceRates([
-                'weight' => $shipment->getPhysicalProperties()->getWeight(),
+                'weight'            => $shipment->getPhysicalProperties()->getWeight(),
+                'volumetric_weight' => $shipment->getPhysicalProperties()->getVolumetricWeight(),
             ]))
             && $this->getMatchedOptions($shipment, $serviceRates);
     }

--- a/tests/Feature/MyParcelComApiTest.php
+++ b/tests/Feature/MyParcelComApiTest.php
@@ -21,6 +21,7 @@ use MyParcelCom\ApiSdk\Resources\Interfaces\ShipmentInterface;
 use MyParcelCom\ApiSdk\Resources\Interfaces\ShipmentStatusInterface;
 use MyParcelCom\ApiSdk\Resources\Interfaces\ShopInterface;
 use MyParcelCom\ApiSdk\Resources\Interfaces\StatusInterface;
+use MyParcelCom\ApiSdk\Resources\PhysicalProperties;
 use MyParcelCom\ApiSdk\Resources\Shipment;
 use MyParcelCom\ApiSdk\Tests\Traits\MocksApiCommunication;
 use PHPUnit\Framework\TestCase;
@@ -595,9 +596,35 @@ class MyParcelComApiTest extends TestCase
     /** @test */
     public function testRetrievingServiceRatesConsidersVolumetricWeight()
     {
-        $this->assertFalse(true);
+        $recipient = (new Address())
+            ->setFirstName('Hank')
+            ->setLastName('Mozzy')
+            ->setCity('London')
+            ->setStreet1('Allen Street')
+            ->setStreetNumber(1)
+            ->setPostalCode('W8 6UX')
+            ->setCountryCode('GB');
 
-        // TODO: Implement.
+        $physicalProperties = new PhysicalProperties();
+        $physicalProperties
+            ->setWeight(500)
+            ->setLength(400)
+            ->setHeight(400)
+            ->setWeight(400);
+
+        $shipment = (new Shipment())
+            ->setPhysicalProperties($physicalProperties)
+            ->setRecipientAddress($recipient);
+
+        $volumetricWeight = $shipment->calculateVolumetricWeight();
+
+        $serviceRates = $this->api->getServiceRatesForShipment($shipment);
+        $this->assertInstanceOf(CollectionInterface::class, $serviceRates);
+        foreach ($serviceRates as $serviceRate) {
+            $this->assertInstanceOf(ServiceRateInterface::class, $serviceRate);
+            $this->assertGreaterThanOrEqual(500, $serviceRate->getWeightMax());
+            $this->assertLessThanOrEqual(500, $serviceRate->getWeightMin());
+        }
     }
 
     /** @test */

--- a/tests/Feature/MyParcelComApiTest.php
+++ b/tests/Feature/MyParcelComApiTest.php
@@ -593,6 +593,14 @@ class MyParcelComApiTest extends TestCase
     }
 
     /** @test */
+    public function testRetrievingServiceRatesConsidersVolumetricWeight()
+    {
+        $this->assertFalse(true);
+
+        // TODO: Implement.
+    }
+
+    /** @test */
     public function testGetShipments()
     {
         $shipments = $this->api->getShipments();

--- a/tests/Feature/MyParcelComApiTest.php
+++ b/tests/Feature/MyParcelComApiTest.php
@@ -610,7 +610,7 @@ class MyParcelComApiTest extends TestCase
             ->setWeight(500)
             ->setLength(400)
             ->setHeight(400)
-            ->setWeight(400);
+            ->setWidth(400);
 
         $shipment = (new Shipment())
             ->setPhysicalProperties($physicalProperties)

--- a/tests/Feature/MyParcelComApiTest.php
+++ b/tests/Feature/MyParcelComApiTest.php
@@ -616,14 +616,14 @@ class MyParcelComApiTest extends TestCase
             ->setPhysicalProperties($physicalProperties)
             ->setRecipientAddress($recipient);
 
-        $volumetricWeight = $shipment->calculateVolumetricWeight();
+        $volumetricWeight = $shipment->getVolumetricWeight();
 
         $serviceRates = $this->api->getServiceRatesForShipment($shipment);
         $this->assertInstanceOf(CollectionInterface::class, $serviceRates);
         foreach ($serviceRates as $serviceRate) {
             $this->assertInstanceOf(ServiceRateInterface::class, $serviceRate);
-            $this->assertGreaterThanOrEqual(500, $serviceRate->getWeightMax());
-            $this->assertLessThanOrEqual(500, $serviceRate->getWeightMin());
+            $this->assertGreaterThanOrEqual($volumetricWeight, $serviceRate->getWeightMax());
+            $this->assertLessThanOrEqual($volumetricWeight, $serviceRate->getWeightMin());
         }
     }
 

--- a/tests/Feature/Proxy/ShipmentProxyTest.php
+++ b/tests/Feature/Proxy/ShipmentProxyTest.php
@@ -172,12 +172,11 @@ class ShipmentProxyTest extends TestCase
 
         $this->assertInstanceOf(PhysicalPropertiesInterface::class, $this->shipmentProxy->getPhysicalProperties());
         $this->assertEquals(24, $this->shipmentProxy->getPhysicalProperties()->getHeight());
-        $this->assertEquals(24, $this->shipmentProxy->getPhysicalProperties()->getWeight());
+        $this->assertEquals(50, $this->shipmentProxy->getPhysicalProperties()->getWidth());
         $this->assertEquals(50, $this->shipmentProxy->getPhysicalProperties()->getLength());
         $this->assertEquals(0.06, $this->shipmentProxy->getPhysicalProperties()->getVolume());
         $this->assertEquals(24, $this->shipmentProxy->getPhysicalProperties()->getWeight());
-        $this->assertTrue(false);
-        // TODO: Add Volumetric weight assertion?
+        $this->assertEquals(12, $this->shipmentProxy->getPhysicalProperties()->getVolumetricWeight());
 
         $customs = $this->shipmentProxy->getCustoms();
         $this->assertInstanceOf(CustomsInterface::class, $customs);

--- a/tests/Feature/Proxy/ShipmentProxyTest.php
+++ b/tests/Feature/Proxy/ShipmentProxyTest.php
@@ -176,6 +176,8 @@ class ShipmentProxyTest extends TestCase
         $this->assertEquals(50, $this->shipmentProxy->getPhysicalProperties()->getLength());
         $this->assertEquals(0.06, $this->shipmentProxy->getPhysicalProperties()->getVolume());
         $this->assertEquals(24, $this->shipmentProxy->getPhysicalProperties()->getWeight());
+        $this->assertTrue(false);
+        // TODO: Add Volumetric weight assertion?
 
         $customs = $this->shipmentProxy->getCustoms();
         $this->assertInstanceOf(CustomsInterface::class, $customs);

--- a/tests/Feature/ResourceFactoryTest.php
+++ b/tests/Feature/ResourceFactoryTest.php
@@ -261,19 +261,20 @@ class ResourceFactoryTest extends TestCase
             'id'            => 'service-id-9001',
             'type'          => 'services',
             'attributes'    => [
-                'name'            => 'Easy Delivery Service',
-                'package_type'    => ServiceInterface::PACKAGE_TYPE_PARCEL,
-                'transit_time'    => [
+                'name'                   => 'Easy Delivery Service',
+                'package_type'           => ServiceInterface::PACKAGE_TYPE_PARCEL,
+                'transit_time'           => [
                     'min' => 2,
                     'max' => 5,
                 ],
-                'handover_method' => 'drop-off',
-                'delivery_days'   => [
+                'handover_method'        => 'drop-off',
+                'delivery_days'          => [
                     'Monday',
                     'Wednesday',
                     'Friday',
                 ],
-                'delivery_method' => 'delivery',
+                'delivery_method'        => 'delivery',
+                'uses_volumetric_weight' => true,
             ],
             'relationships' => [
                 'carrier' => [
@@ -436,11 +437,12 @@ class ResourceFactoryTest extends TestCase
                     'currency' => 'EUR',
                 ],
                 'physical_properties' => [
-                    'weight' => 1000,
-                    'length' => 1100,
-                    'height' => 1300,
-                    'width'  => 1400,
-                    'volume' => 2002,
+                    'weight'            => 1000,
+                    'length'            => 1100,
+                    'height'            => 1300,
+                    'width'             => 1400,
+                    'volume'            => 2002,
+                    'volumetric_weight' => 400400,
                 ],
                 'recipient_address'   => [
                     'street_1'             => 'Diagonally',
@@ -524,13 +526,13 @@ class ResourceFactoryTest extends TestCase
                 'total_value'         => [
                     'amount'   => 1337,
                     'currency' => 'EUR',
-                ],
                 'physical_properties' => [
-                    'weight' => 1000,
-                    'length' => 1100,
-                    'height' => 1300,
-                    'width'  => 1400,
-                    'volume' => 2002,
+                    'weight'            => 1000,
+                    'length'            => 1100,
+                    'height'            => 1300,
+                    'width'             => 1400,
+                    'volume'            => 2002,
+                    'volumetric_weight' => 400400,
                 ],
                 'recipient_address'   => [
                     'street_1'             => 'Diagonally',

--- a/tests/Feature/ResourceFactoryTest.php
+++ b/tests/Feature/ResourceFactoryTest.php
@@ -526,6 +526,7 @@ class ResourceFactoryTest extends TestCase
                 'total_value'         => [
                     'amount'   => 1337,
                     'currency' => 'EUR',
+                ],
                 'physical_properties' => [
                     'weight'            => 1000,
                     'length'            => 1100,

--- a/tests/Stubs/get/https---api-service-rates/filter-weight--500/filter-volumetric_weight--12800/filter-service--a3057e77-005b-4945-a41c-20ddbe4dab08/page-number--1/page-size--30.json
+++ b/tests/Stubs/get/https---api-service-rates/filter-weight--500/filter-volumetric_weight--12800/filter-service--a3057e77-005b-4945-a41c-20ddbe4dab08/page-number--1/page-size--30.json
@@ -1,0 +1,145 @@
+{
+  "data": [
+    {
+      "id": "f5bf6b2a-f6ef-4866-85e0-af9fb3460410",
+      "type": "service-rates",
+      "attributes": {
+        "weight_min": 0,
+        "weight_max": 25000,
+        "width_max": 300,
+        "height_max": 560,
+        "volume_max": 126,
+        "length_max": 750,
+        "step_size": 1000,
+        "price": {
+          "amount": 400,
+          "currency": "EUR"
+        }
+      },
+      "links": {
+        "self": "https://api/service-rates/f5bf6b2a-f6ef-4866-85e0-af9fb3460410"
+      },
+      "relationships": {
+        "service_options": {
+          "data": [
+            {
+              "id": "91e45009-c7bf-46ea-92e0-c55120f38225",
+              "type": "service-options",
+              "meta": {
+                "included": false,
+                "price": {
+                  "currency": "EUR",
+                  "amount": 250
+                }
+              }
+            },
+            {
+              "id": "8ce66012-99de-47fb-9d6e-81b6cdf40708",
+              "type": "service-options",
+              "meta": {
+                "included": false,
+                "price": {
+                  "currency": "EUR",
+                  "amount": 100
+                }
+              }
+            },
+            {
+              "id": "8e24afc1-2edf-48a1-a531-95ab6c0c750b",
+              "type": "service-options",
+              "meta": {
+                "included": true,
+                "price": {
+                  "currency": "EUR",
+                  "amount": 0
+                }
+              }
+            },
+            {
+              "id": "6dd892c1-9b84-4de5-9209-4f8fed1aa165",
+              "type": "service-options",
+              "meta": {
+                "included": false,
+                "price": {
+                  "currency": "EUR",
+                  "amount": 100
+                }
+              }
+            },
+            {
+              "id": "86bc4b41-e064-4653-b850-2b4a738ac2fc",
+              "type": "service-options",
+              "meta": {
+                "included": false,
+                "price": {
+                  "currency": "GBP",
+                  "amount": 775
+                }
+              }
+            },
+            {
+              "id": "b2edbf69-2dae-4e75-bca1-3d473d765fcd",
+              "type": "service-options",
+              "meta": {
+                "included": false,
+                "price": {
+                  "currency": "GBP",
+                  "amount": 400
+                }
+              }
+            },
+            {
+              "id": "b73d7bf2-8705-4509-bb63-a2fa1f19d4b2",
+              "type": "service-options",
+              "meta": {
+                "included": false,
+                "price": {
+                  "currency": "GBP",
+                  "amount": 400
+                }
+              }
+            },
+            {
+              "id": "a3119bf8-0e96-476f-afc7-6f403b302bd4",
+              "type": "service-options",
+              "meta": {
+                "included": true,
+                "price": {
+                  "currency": "GBP",
+                  "amount": 0
+                }
+              }
+            }
+          ]
+        },
+        "service": {
+          "data": {
+            "id": "a3057e77-005b-4945-a41c-20ddbe4dab08",
+            "type": "services"
+          },
+          "links": {
+            "related": "https://api/services/a3057e77-005b-4945-a41c-20ddbe4dab08"
+          }
+        },
+        "contract": {
+          "data": {
+            "id": "a33dadb9-de8e-4731-90d2-cf760e3f7cff",
+            "type": "contracts"
+          },
+          "links": {
+            "related": "https://api/contracts/a33dadb9-de8e-4731-90d2-cf760e3f7cff"
+          }
+        }
+      }
+    }
+  ],
+  "meta": {
+    "total_pages": 1,
+    "total_records": 2
+  },
+  "links": {
+    "self": "https://api/service-rates?filter[service]=a3057e77-005b-4945-a41c-20ddbe4dab08&filter[weight]=500&page[size]=30&page[number]=1",
+    "first": "https://api/service-rates?filter[service]=a3057e77-005b-4945-a41c-20ddbe4dab08&filter[weight]=500&page[size]=30&page[number]=1",
+    "last": "https://api/service-rates?filter[service]=a3057e77-005b-4945-a41c-20ddbe4dab08&filter[weight]=500&page[size]=30&page[number]=1"
+  }
+}

--- a/tests/Stubs/get/https---api-services/filter-has_active_contract--true/filter-address_from--country_code--GB/filter-address_from--country_code--GB.json
+++ b/tests/Stubs/get/https---api-services/filter-has_active_contract--true/filter-address_from--country_code--GB/filter-address_from--country_code--GB.json
@@ -28,7 +28,8 @@
             "country_code": "GB",
             "region_code": "NIR"
           }
-        ]
+        ],
+        "uses_volumetric_weight": true
       },
       "links": {
         "self": "https://api/services/a3057e77-005b-4945-a41c-20ddbe4dab08",

--- a/tests/Stubs/get/https---api-services/filter-has_active_contract--true/filter-address_from--country_code--GB/filter-address_to--country_code--GB.json
+++ b/tests/Stubs/get/https---api-services/filter-has_active_contract--true/filter-address_from--country_code--GB/filter-address_to--country_code--GB.json
@@ -28,7 +28,8 @@
             "country_code": "GB",
             "region_code": "NIR"
           }
-        ]
+        ],
+        "uses_volumetric_weight": true
       },
       "links": {
         "self": "https://api/services/a3057e77-005b-4945-a41c-20ddbe4dab08",

--- a/tests/Stubs/get/https---api-shipments-shipment-id-1.json
+++ b/tests/Stubs/get/https---api-shipments-shipment-id-1.json
@@ -83,14 +83,8 @@
         "width": 50,
         "length": 50,
         "volume": 0.06,
-        "weight": 24
-      },
-      "physical_properties_verified": {
-        "height": 240,
-        "width": 500,
-        "length": 500,
-        "volume": 60,
-        "weight": 240
+        "weight": 24,
+        "volumetric_weight": 12
       },
       "items": [
         {
@@ -146,15 +140,6 @@
             "id": "service-option-id-1"
           }
         ]
-      },
-      "parent": {
-        "data": {
-          "type": "shipments",
-          "id": "shipment-id-0"
-        },
-        "links": {
-          "related": "https://api/shipments/shipment-id-0"
-        }
       },
       "shop": {
         "data": {

--- a/tests/Stubs/get/https---api-shipments/filter-shop--shop-id-1/page-number--1/page-size--30.json
+++ b/tests/Stubs/get/https---api-shipments/filter-shop--shop-id-1/page-number--1/page-size--30.json
@@ -67,44 +67,44 @@
             "phone_number": "+31 234 567 890"
           }
         },
+        "items": [
+          {
+            "sku": "123456789",
+            "description": "OnePlus X",
+            "item_value": {
+              "amount": 100,
+              "currency": "GBP"
+            },
+            "quantity": 2,
+            "hs_code": "8517.12.00",
+            "origin_country_code": "GB"
+          },
+          {
+            "sku": "213425",
+            "description": "OnePlus One",
+            "item_value": {
+              "amount": 200,
+              "currency": "GBP"
+            },
+            "quantity": 3,
+            "hs_code": "8517.12.00",
+            "origin_country_code": "GB"
+          },
+          {
+            "sku": "6876",
+            "description": "OnePlus Two",
+            "item_value": {
+              "amount": 300,
+              "currency": "GBP"
+            },
+            "quantity": 1,
+            "hs_code": "8517.12.00",
+            "origin_country_code": "GB"
+          }
+        ],
         "customs": {
           "content_type": "documents",
           "invoice_number": "NO.5",
-          "items": [
-            {
-              "sku": "123456789",
-              "description": "OnePlus X",
-              "item_value": {
-                "amount": 100,
-                "currency": "GBP"
-              },
-              "quantity": 2,
-              "hs_code": "8517.12.00",
-              "origin_country_code": "GB"
-            },
-            {
-              "sku": "213425",
-              "description": "OnePlus One",
-              "item_value": {
-                "amount": 200,
-                "currency": "GBP"
-              },
-              "quantity": 3,
-              "hs_code": "8517.12.00",
-              "origin_country_code": "GB"
-            },
-            {
-              "sku": "6876",
-              "description": "OnePlus Two",
-              "item_value": {
-                "amount": 300,
-                "currency": "GBP"
-              },
-              "quantity": 1,
-              "hs_code": "8517.12.00",
-              "origin_country_code": "GB"
-            }
-          ],
           "non_delivery": "return",
           "incoterm": "DDU"
         },
@@ -125,15 +125,10 @@
           "width": 50,
           "length": 50,
           "volume": 0.06,
-          "weight": 24
+          "weight": 24,
+          "volumetric_weight": 12
         },
-        "physical_properties_verified": {
-          "height": 240,
-          "width": 500,
-          "length": 500,
-          "volume": 60,
-          "weight": 240
-        },
+        "register_at": 1526913941,
         "created_at": 1504801719,
         "updated_at": 1504801719,
         "synced_at": 1504801719
@@ -146,15 +141,6 @@
               "id": "service-option-id-1"
             }
           ]
-        },
-        "parent": {
-          "data": {
-            "type": "shipments",
-            "id": "shipment-id-0"
-          },
-          "links": {
-            "related": "https://api/shipments/shipment-id-0"
-          }
         },
         "shop": {
           "data": {

--- a/tests/Stubs/get/https---api-shipments/page-number--1/page-size--30.json
+++ b/tests/Stubs/get/https---api-shipments/page-number--1/page-size--30.json
@@ -125,14 +125,8 @@
           "width": 50,
           "length": 50,
           "volume": 0.06,
-          "weight": 24
-        },
-        "physical_properties_verified": {
-          "height": 240,
-          "width": 500,
-          "length": 500,
-          "volume": 60,
-          "weight": 240
+          "weight": 24,
+          "volumetric_weight": 12
         },
         "register_at": 1526913941,
         "created_at": 1504801719,

--- a/tests/Traits/MocksContract.php
+++ b/tests/Traits/MocksContract.php
@@ -50,9 +50,10 @@ trait MocksContract
      * @param int                      $weight
      * @param ServiceInterface|null    $service
      * @param ServiceOptionInterface[] $serviceOptions
+     * @param null|int                 $volumetricWeight
      * @return ShipmentInterface
      */
-    protected function getMockedShipment($weight = 5000, ServiceInterface $service = null, array $serviceOptions = [])
+    protected function getMockedShipment($weight = 5000, ServiceInterface $service = null, array $serviceOptions = [], $volumetricWeight = null)
     {
         $physicalPropertiesMock = $this->getMockBuilder(PhysicalPropertiesInterface::class)
             ->disableOriginalConstructor()
@@ -60,9 +61,8 @@ trait MocksContract
             ->disableArgumentCloning()
             ->disallowMockingUnknownTypes()
             ->getMock();
-        $physicalPropertiesMock
-            ->method('getWeight')
-            ->willReturn($weight);
+        $physicalPropertiesMock->method('getWeight')->willReturn($weight);
+        $physicalPropertiesMock->method('getVolumetricWeight')->willReturn($volumetricWeight);
 
         $contractMock = $this->getMockBuilder(ContractInterface::class)
             ->disableOriginalConstructor()
@@ -115,9 +115,10 @@ trait MocksContract
     /**
      * @param ServiceRateInterface[] $serviceRates
      * @param string|null            $deliveryMethod
+     * @param bool                   $usesVolumetricWeight
      * @return ServiceInterface
      */
-    protected function getMockedService(array $serviceRates = [], $deliveryMethod = null)
+    protected function getMockedService(array $serviceRates = [], $deliveryMethod = null, $usesVolumetricWeight = false)
     {
         $mock = $this->getMockBuilder(ServiceInterface::class)
             ->disableOriginalConstructor()
@@ -131,6 +132,8 @@ trait MocksContract
         $mock
             ->method('getDeliveryMethod')
             ->willReturn($deliveryMethod);
+        $mock->method('usesVolumetricWeight')
+            ->willReturn($usesVolumetricWeight);
 
         return $mock;
     }

--- a/tests/Unit/PhysicalPropertiesTest.php
+++ b/tests/Unit/PhysicalPropertiesTest.php
@@ -55,6 +55,14 @@ class PhysicalPropertiesTest extends TestCase
     }
 
     /** @test */
+    public function testVolumetricWeight()
+    {
+        $this->assertTrue(false);
+
+        // TODO: Implement test.
+    }
+
+    /** @test */
     public function testJsonSerialize()
     {
         $physicalProperties = (new PhysicalProperties())

--- a/tests/Unit/PhysicalPropertiesTest.php
+++ b/tests/Unit/PhysicalPropertiesTest.php
@@ -58,7 +58,16 @@ class PhysicalPropertiesTest extends TestCase
     public function testVolumetricWeight()
     {
         $physicalProperties = new PhysicalProperties();
-        $this->assertEquals(1500, $physicalProperties->setVolumetricWeight(1500)->getVolumetricWeight());
+        $physicalProperties->setHeight(60);
+        $physicalProperties->setWidth(70);
+        $physicalProperties->setLength(80);
+
+        // Calculates the volumetric weight if not set yet.
+        $this->assertEquals(68, $physicalProperties->getVolumetricWeight());
+
+        // If volumetric weight is set, it should return the already set value.
+        $physicalProperties->setVolumetricWeight(1500);
+        $this->assertEquals(1500, $physicalProperties->getVolumetricWeight());
     }
 
     /** @test */
@@ -69,14 +78,16 @@ class PhysicalPropertiesTest extends TestCase
             ->setLength(1100)
             ->setVolume(1200)
             ->setHeight(1300)
-            ->setWidth(1400);
+            ->setWidth(1400)
+            ->setVolumetricWeight(1500);
 
         $this->assertEquals([
-            'weight' => 1000,
-            'length' => 1100,
-            'volume' => 1200,
-            'height' => 1300,
-            'width'  => 1400,
+            'weight'            => 1000,
+            'length'            => 1100,
+            'volume'            => 1200,
+            'height'            => 1300,
+            'width'             => 1400,
+            'volumetric_weight' => 1500,
         ], $physicalProperties->jsonSerialize());
     }
 }

--- a/tests/Unit/PhysicalPropertiesTest.php
+++ b/tests/Unit/PhysicalPropertiesTest.php
@@ -58,14 +58,21 @@ class PhysicalPropertiesTest extends TestCase
     public function testVolumetricWeight()
     {
         $physicalProperties = new PhysicalProperties();
+
         $physicalProperties->setHeight(60);
         $physicalProperties->setWidth(70);
+
+        // If not all dimensions are set, and volumetric weight isn't set either,
+        // getVolumetricWeight should return null.
+        $this->assertNull($physicalProperties->getVolumetricWeight());
+
         $physicalProperties->setLength(80);
 
-        // Calculates the volumetric weight if not set yet.
+        // It calculates the volumetric weight otherwise.
         $this->assertEquals(68, $physicalProperties->getVolumetricWeight());
 
-        // If volumetric weight is set, it should return the already set value.
+        // If volumetric weight is set, it should return the already set value,
+        // regardless of the dimensions.
         $physicalProperties->setVolumetricWeight(1500);
         $this->assertEquals(1500, $physicalProperties->getVolumetricWeight());
     }

--- a/tests/Unit/PhysicalPropertiesTest.php
+++ b/tests/Unit/PhysicalPropertiesTest.php
@@ -57,9 +57,8 @@ class PhysicalPropertiesTest extends TestCase
     /** @test */
     public function testVolumetricWeight()
     {
-        $this->assertTrue(false);
-
-        // TODO: Implement test.
+        $physicalProperties = new PhysicalProperties();
+        $this->assertEquals(1500, $physicalProperties->setVolumetricWeight(1500)->getVolumetricWeight());
     }
 
     /** @test */

--- a/tests/Unit/PriceCalculatorTest.php
+++ b/tests/Unit/PriceCalculatorTest.php
@@ -46,7 +46,7 @@ class PriceCalculatorTest extends TestCase
     }
 
     /** @test */
-    public function testItTotalPriceIsNullWhenOptionPriceIsNull()
+    public function testTheTotalPriceIsNullWhenOptionPriceIsNull()
     {
         $serviceOptionMocks = [
             $this->getMockedServiceOption('service-option-id-uno', 250),
@@ -188,13 +188,5 @@ class PriceCalculatorTest extends TestCase
         $this->expectException(InvalidResourceException::class);
         $this->expectExceptionMessage('Cannot calculate shipment price without a set contract.');
         $calculator->calculate($shipment);
-    }
-
-    /** @test */
-    public function testItConsidersVolumetricWeightWhenTheServiceUsesIt()
-    {
-        $this->assertTrue(false);
-
-        // TODO: Implement.
     }
 }

--- a/tests/Unit/PriceCalculatorTest.php
+++ b/tests/Unit/PriceCalculatorTest.php
@@ -189,4 +189,12 @@ class PriceCalculatorTest extends TestCase
         $this->expectExceptionMessage('Cannot calculate shipment price without a set contract.');
         $calculator->calculate($shipment);
     }
+
+    /** @test */
+    public function testItConsidersVolumetricWeightWhenTheServiceUsesIt()
+    {
+        $this->assertTrue(false);
+
+        // TODO: Implement.
+    }
 }

--- a/tests/Unit/ServiceMatcherTest.php
+++ b/tests/Unit/ServiceMatcherTest.php
@@ -181,4 +181,12 @@ class ServiceMatcherTest extends TestCase
         );
         $this->assertTrue($this->matcher->matches($shipment, $matchingServiceB));
     }
+
+    /** @test */
+    public function testItConsidersVolumetricWeightWhenServiceUsesIt()
+    {
+        $this->assertTrue(false);
+
+        // TODO: Implement.
+    }
 }

--- a/tests/Unit/ServiceMatcherTest.php
+++ b/tests/Unit/ServiceMatcherTest.php
@@ -164,7 +164,7 @@ class ServiceMatcherTest extends TestCase
         $nonMatchingServiceC = $this->getMockedService([], 'pick-up');
         $this->assertFalse($this->matcher->matches($shipment, $nonMatchingServiceC));
 
-        // This service does match the shipment's delivery method and the the service rates match the
+        // This service does match the shipment's delivery method and the service rates match the
         // shipment weight, but it doesn't have the right options.
         $nonMatchingServiceC = $this->getMockedService($nonMatchingServiceRates, 'pick-up');
         $this->assertFalse($this->matcher->matches($shipment, $nonMatchingServiceC));
@@ -180,13 +180,5 @@ class ServiceMatcherTest extends TestCase
             'pick-up'
         );
         $this->assertTrue($this->matcher->matches($shipment, $matchingServiceB));
-    }
-
-    /** @test */
-    public function testItConsidersVolumetricWeightWhenServiceUsesIt()
-    {
-        $this->assertTrue(false);
-
-        // TODO: Implement.
     }
 }

--- a/tests/Unit/ServiceTest.php
+++ b/tests/Unit/ServiceTest.php
@@ -209,29 +209,31 @@ class ServiceTest extends TestCase
             ->setDeliveryDays(['Monday'])
             ->setCarrier($carrier)
             ->setRegionFrom($regionFrom)
-            ->setRegionTo($regionTo);
+            ->setRegionTo($regionTo)
+            ->setUsesVolumetricWeight(true);
 
         $this->assertEquals([
             'id'            => 'service-id',
             'type'          => 'services',
             'attributes'    => [
-                'name'            => 'Easy Delivery Service',
-                'package_type'    => Service::PACKAGE_TYPE_PARCEL,
-                'transit_time'    => [
+                'name'                   => 'Easy Delivery Service',
+                'package_type'           => Service::PACKAGE_TYPE_PARCEL,
+                'transit_time'           => [
                     'min' => 7,
                     'max' => 14,
                 ],
-                'handover_method' => 'drop-off',
-                'delivery_days'   => [
+                'handover_method'        => 'drop-off',
+                'delivery_days'          => [
                     'Monday',
                 ],
-                'regions_from'    => [
+                'uses_volumetric_weight' => true,
+                'regions_from'           => [
                     [
                         'country_code' => 'GB',
                         'region_code'  => 'ENG',
                     ],
                 ],
-                'regions_to'      => [
+                'regions_to'             => [
                     [
                         'country_code' => 'GB',
                         'region_code'  => 'ENG',

--- a/tests/Unit/ShipmentTest.php
+++ b/tests/Unit/ShipmentTest.php
@@ -13,6 +13,7 @@ use MyParcelCom\ApiSdk\Resources\Interfaces\ServiceOptionInterface;
 use MyParcelCom\ApiSdk\Resources\Interfaces\ShipmentItemInterface;
 use MyParcelCom\ApiSdk\Resources\Interfaces\ShipmentStatusInterface;
 use MyParcelCom\ApiSdk\Resources\Interfaces\ShopInterface;
+use MyParcelCom\ApiSdk\Resources\PhysicalProperties;
 use MyParcelCom\ApiSdk\Resources\Shipment;
 use PHPUnit\Framework\TestCase;
 
@@ -392,6 +393,26 @@ class ShipmentTest extends TestCase
         $shipment->setTotalValueCurrency('EUR');
 
         $this->assertEquals('EUR', $shipment->getTotalValueCurrency());
+    }
+
+    /** @test */
+    public function testItCalculatesVolumetricWeightIfDimensionsAreSet()
+    {
+        $shipment = new Shipment();
+
+        $physicalProperties = $physicalProperties = $this->getMockBuilder(PhysicalPropertiesInterface::class)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->disallowMockingUnknownTypes()
+            ->getMock();
+
+        $physicalProperties->method('getWidth')->willReturn(400);
+        $physicalProperties->method('getHeight')->willReturn(500);
+        $physicalProperties->method('getLength')->willReturn(600);
+
+        // 400 * 500 * 600 / 5000
+        $this->assertEquals(24000, $shipment->getVolumetricWeight());
     }
 
     /** @test */

--- a/tests/Unit/ShipmentTest.php
+++ b/tests/Unit/ShipmentTest.php
@@ -396,26 +396,6 @@ class ShipmentTest extends TestCase
     }
 
     /** @test */
-    public function testItCalculatesVolumetricWeightIfDimensionsAreSet()
-    {
-        $shipment = new Shipment();
-
-        $physicalProperties = $physicalProperties = $this->getMockBuilder(PhysicalPropertiesInterface::class)
-            ->disableOriginalConstructor()
-            ->disableOriginalClone()
-            ->disableArgumentCloning()
-            ->disallowMockingUnknownTypes()
-            ->getMock();
-
-        $physicalProperties->method('getWidth')->willReturn(400);
-        $physicalProperties->method('getHeight')->willReturn(500);
-        $physicalProperties->method('getLength')->willReturn(600);
-
-        // 400 * 500 * 600 / 5000
-        $this->assertEquals(24000, $shipment->getVolumetricWeight());
-    }
-
-    /** @test */
     public function testJsonSerialize()
     {
         $recipientAddress = $this->getMockBuilder(AddressInterface::class)


### PR DESCRIPTION
**Changes**
- Implemented volumetric weight for service rate retrieval and shipment creation flow.
- Fixed a bug where all available service rates for all services were returned when no services could be found for a shipment (it populated the filter[service] with nothing, so instead, the service rates for all services were returned).

**Related Issues**
- https://myparcelcombv.atlassian.net/browse/MP-2457