### PR TITLE
✨ Cache TTL can be changed when getting a shipment

### DIFF
--- a/src/MyParcelComApi.php
+++ b/src/MyParcelComApi.php
@@ -133,7 +133,7 @@ class MyParcelComApi implements MyParcelComApiInterface
     /**
      * {@inheritdoc}
      */
-    public function getRegions($filters = [])
+    public function getRegions($filters = [], $ttl = self::TTL_WEEK)
     {
         $url = (new UrlBuilder($this->apiUri . self::PATH_REGIONS));
 
@@ -157,7 +157,7 @@ class MyParcelComApi implements MyParcelComApiInterface
         }
 
         // These resources can be stored for a week.
-        $regions = $this->getRequestCollection($url->getUrl(), self::TTL_WEEK);
+        $regions = $this->getRequestCollection($url->getUrl(), $ttl);
 
         if ($regions->count() > 0 || !isset($filters['region_code'])) {
             return $regions;
@@ -166,16 +166,16 @@ class MyParcelComApi implements MyParcelComApiInterface
         // Fallback to the country if the specific region is not in the API.
         $url->addQuery(['filter[region_code]' => null]);
 
-        return $this->getRequestCollection($url->getUrl(), self::TTL_WEEK);
+        return $this->getRequestCollection($url->getUrl(), $ttl);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getCarriers()
+    public function getCarriers($ttl = self::TTL_WEEK)
     {
         // These resources can be stored for a week.
-        return $this->getRequestCollection($this->apiUri . self::PATH_CARRIERS, self::TTL_WEEK);
+        return $this->getRequestCollection($this->apiUri . self::PATH_CARRIERS, $ttl);
     }
 
     /**
@@ -187,7 +187,8 @@ class MyParcelComApi implements MyParcelComApiInterface
         $streetName = null,
         $streetNumber = null,
         CarrierInterface $specificCarrier = null,
-        $onlyActiveContracts = true
+        $onlyActiveContracts = true,
+        $ttl = self::TTL_WEEK
     ) {
         $carriers = $this->determineCarriersForPudoLocations($onlyActiveContracts, $specificCarrier);
 
@@ -218,7 +219,7 @@ class MyParcelComApi implements MyParcelComApiInterface
 
             // These resources can be stored for a week.
             try {
-                $resources = $this->getResourcesArray($carrierUri, self::TTL_WEEK);
+                $resources = $this->getResourcesArray($carrierUri, $ttl);
             } catch (RequestException $exception) {
                 // When we are trying to fetch pudo locations for a specific
                 // carrier, we want to be able to distinct between 'no results'
@@ -248,19 +249,19 @@ class MyParcelComApi implements MyParcelComApiInterface
     /**
      * {@inheritdoc}
      */
-    public function getShops()
+    public function getShops($ttl = self::TTL_WEEK)
     {
         // These resources can be stored for a week. Or should be removed from
         // cache when updated
-        return $this->getRequestCollection($this->apiUri . self::PATH_SHOPS, self::TTL_WEEK);
+        return $this->getRequestCollection($this->apiUri . self::PATH_SHOPS, $ttl);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getDefaultShop()
+    public function getDefaultShop($ttl = self::TTL_WEEK)
     {
-        $shops = $this->getResourcesArray($this->apiUri . self::PATH_SHOPS, self::TTL_WEEK);
+        $shops = $this->getResourcesArray($this->apiUri . self::PATH_SHOPS, $ttl);
 
         // For now the oldest shop will be the default shop.
         usort($shops, function (ShopInterface $shopA, ShopInterface $shopB) {
@@ -273,13 +274,16 @@ class MyParcelComApi implements MyParcelComApiInterface
     /**
      * {@inheritdoc}
      */
-    public function getServices(ShipmentInterface $shipment = null, array $filters = ['has_active_contract' => 'true'])
-    {
+    public function getServices(
+        ShipmentInterface $shipment = null,
+        array $filters = ['has_active_contract' => 'true'],
+        $ttl = self::TTL_WEEK
+    ) {
         $url = new UrlBuilder($this->apiUri . self::PATH_SERVICES);
         $url->addQuery($this->arrayToFilters($filters));
 
         if ($shipment === null) {
-            return $this->getRequestCollection($url->getUrl(), self::TTL_WEEK);
+            return $this->getRequestCollection($url->getUrl(), $ttl);
         }
 
         if ($shipment->getSenderAddress() === null) {
@@ -308,7 +312,7 @@ class MyParcelComApi implements MyParcelComApiInterface
         ]));
 
         // Services can be cached for a week.
-        $services = $this->getResourcesArray($url->getUrl(), self::TTL_WEEK);
+        $services = $this->getResourcesArray($url->getUrl(), $ttl);
 
         $matcher = new ServiceMatcher();
         $services = array_values(array_filter($services, function (ServiceInterface $service) use ($shipment, $matcher) {
@@ -321,7 +325,7 @@ class MyParcelComApi implements MyParcelComApiInterface
     /**
      * {@inheritdoc}
      */
-    public function getServicesForCarrier(CarrierInterface $carrier)
+    public function getServicesForCarrier(CarrierInterface $carrier, $ttl = self::TTL_WEEK)
     {
         $url = new UrlBuilder($this->apiUri . self::PATH_SERVICES);
         $url->addQuery($this->arrayToFilters([
@@ -329,24 +333,24 @@ class MyParcelComApi implements MyParcelComApiInterface
             'carrier'             => $carrier->getId(),
         ]));
 
-        return $this->getRequestCollection($url->getUrl(), self::TTL_WEEK);
+        return $this->getRequestCollection($url->getUrl(), $ttl);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getServiceRates(array $filters = ['has_active_contract' => 'true'])
+    public function getServiceRates(array $filters = ['has_active_contract' => 'true'], $ttl = self::TTL_WEEK)
     {
         $url = new UrlBuilder($this->apiUri . self::PATH_SERVICE_RATES);
         $url->addQuery($this->arrayToFilters($filters));
 
-        return $this->getRequestCollection($url->getUrl(), self::TTL_WEEK);
+        return $this->getRequestCollection($url->getUrl(), $ttl);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getServiceRatesForShipment(ShipmentInterface $shipment)
+    public function getServiceRatesForShipment(ShipmentInterface $shipment, $ttl = self::TTL_WEEK)
     {
         $services = $this->getServices($shipment);
         $serviceIds = [];
@@ -366,7 +370,7 @@ class MyParcelComApi implements MyParcelComApiInterface
             'service'             => implode(',', $serviceIds),
         ]));
 
-        $serviceRates = $this->getRequestCollection($url->getUrl(), self::TTL_WEEK);
+        $serviceRates = $this->getRequestCollection($url->getUrl(), $ttl);
 
         $shipmentOptionIds = array_map(function (ServiceOptionInterface $serviceOption) {
             return $serviceOption->getId();
@@ -389,7 +393,7 @@ class MyParcelComApi implements MyParcelComApiInterface
     /**
      * {@inheritdoc}
      */
-    public function getShipments(ShopInterface $shop = null)
+    public function getShipments(ShopInterface $shop = null, $ttl = self::TTL_WEEK)
     {
         $url = new UrlBuilder($this->apiUri . self::PATH_SHIPMENTS);
 
@@ -397,7 +401,7 @@ class MyParcelComApi implements MyParcelComApiInterface
             $url->addQuery(['filter[shop]' => $shop->getId()]);
         }
 
-        return $this->getRequestCollection($url->getUrl(), self::TTL_WEEK);
+        return $this->getRequestCollection($url->getUrl(), $ttl);
     }
 
     /**

--- a/src/MyParcelComApi.php
+++ b/src/MyParcelComApi.php
@@ -403,9 +403,9 @@ class MyParcelComApi implements MyParcelComApiInterface
     /**
      * {@inheritdoc}
      */
-    public function getShipment($id)
+    public function getShipment($id, $ttl = null)
     {
-        return $this->getResourceById(ResourceInterface::TYPE_SHIPMENT, $id);
+        return $this->getResourceById(ResourceInterface::TYPE_SHIPMENT, $id, $ttl);
     }
 
     /**
@@ -731,13 +731,15 @@ class MyParcelComApi implements MyParcelComApiInterface
     /**
      * @param string $resourceType
      * @param string $id
+     * @param int    $ttl
      * @return ResourceInterface
      * @throws RequestException
      */
-    public function getResourceById($resourceType, $id)
+    public function getResourceById($resourceType, $id, $ttl = self::TTL_10MIN)
     {
         $resources = $this->getResourcesArray(
-            $this->getResourceUri($resourceType, $id)
+            $this->getResourceUri($resourceType, $id),
+            $ttl
         );
 
         return reset($resources);

--- a/src/MyParcelComApiInterface.php
+++ b/src/MyParcelComApiInterface.php
@@ -48,17 +48,19 @@ interface MyParcelComApiInterface
      * @see https://docs.myparcel.com/api/resources/regions/#parameters
      *
      * @param array $filters
+     * @param int   $ttl            Cache time to live (in seconds)
      * @return CollectionInterface
      */
-    public function getRegions($filters = []);
+    public function getRegions($filters = [], $ttl = self::TTL_WEEK);
 
     /**
      * Get all the carriers from the API.
      *
+     * @param int   $ttl            Cache time to live (in seconds)
      * @return CollectionInterface
      * @throws MyParcelComException
      */
-    public function getCarriers();
+    public function getCarriers($ttl = self::TTL_WEEK);
 
     /**
      * Get the pick up/drop off locations around a given location. If no carrier
@@ -70,6 +72,7 @@ interface MyParcelComApiInterface
      * @param string|null           $streetNumber
      * @param CarrierInterface|null $specificCarrier
      * @param bool                  $onlyActiveContracts
+     * @param int                   $ttl                    Cache time to live (in seconds)
      * @return CollectionInterface
      */
     public function getPickUpDropOffLocations(
@@ -78,72 +81,85 @@ interface MyParcelComApiInterface
         $streetName = null,
         $streetNumber = null,
         CarrierInterface $specificCarrier = null,
-        $onlyActiveContracts = true
+        $onlyActiveContracts = true,
+        $ttl = self::TTL_WEEK
     );
 
     /**
      * Get the shops from the API.
      *
+     * @param int $ttl              Cache time to live (in seconds)
      * @return CollectionInterface
      * @throws MyParcelComException
      */
-    public function getShops();
+    public function getShops($ttl = self::TTL_WEEK);
 
     /**
      * Get the default shop that will be used when interacting with the API and
      * no specific shop has been set.
      *
+     * @param int $ttl              Cache time to live (in seconds)
      * @return ShopInterface
      * @throws MyParcelComException
      */
-    public function getDefaultShop();
+    public function getDefaultShop($ttl = self::TTL_WEEK);
 
     /**
      * Get all services that can be used for given shipment. If no shipment is
      * provided, all available services are returned.
      *
      * @param ShipmentInterface|null $shipment
+     * @param array                  $filters
+     * @param int                    $ttl       Cache time to live (in seconds)
      * @return CollectionInterface
      * @throws MyParcelComException
      */
-    public function getServices(ShipmentInterface $shipment = null, array $filters = ['has_active_contract' => 'true']);
+    public function getServices(
+        ShipmentInterface $shipment = null,
+        array $filters = ['has_active_contract' => 'true'],
+        $ttl = self::TTL_WEEK
+    );
 
     /**
      * Get all the services that are available for the given carrier.
      *
      * @param CarrierInterface $carrier
+     * @param int              $ttl     Cache time to live (in seconds)
      * @return CollectionInterface
      * @throws MyParcelComException
      */
-    public function getServicesForCarrier(CarrierInterface $carrier);
+    public function getServicesForCarrier(CarrierInterface $carrier, $ttl = self::TTL_WEEK);
 
     /**
      * Retrieves service rates based on the set filters.
      * Available filters are: service, contract and weight.
      *
      * @param array $filters
+     * @param int   $ttl           Cache time to live (in seconds)
      * @return CollectionInterface
      */
-    public function getServiceRates(array $filters = ['has_active_contract' => 'true']);
+    public function getServiceRates(array $filters = ['has_active_contract' => 'true'], $ttl = self::TTL_WEEK);
 
     /**
      * Retrieves service rates based on the shipment.
      * The shipment needs to have a recipient/sender_address and a weight set.
      *
      * @param ShipmentInterface $shipment
+     * @param int               $ttl      Cache time to live (in seconds)
      * @return CollectionInterface
      */
-    public function getServiceRatesForShipment(ShipmentInterface $shipment);
+    public function getServiceRatesForShipment(ShipmentInterface $shipment, $ttl = self::TTL_WEEK);
 
     /**
      * Get shipments for a given shop. If no shop is given the default shop is
      * used.
      *
      * @param ShopInterface|null $shop
+     * @param int                $ttl  Cache time to live (in seconds)
      * @return CollectionInterface
      * @throws MyParcelComException
      */
-    public function getShipments(ShopInterface $shop = null);
+    public function getShipments(ShopInterface $shop = null, $ttl = self::TTL_WEEK);
 
     /**
      * Get a specific shipment from the API.

--- a/src/MyParcelComApiInterface.php
+++ b/src/MyParcelComApiInterface.php
@@ -149,10 +149,11 @@ interface MyParcelComApiInterface
      * Get a specific shipment from the API.
      *
      * @param string $id
+     * @param int    $ttl
      * @return ShipmentInterface
      * @throws MyParcelComException
      */
-    public function getShipment($id);
+    public function getShipment($id, $ttl = null);
 
     /**
      * Creates a given shipment or updates it depending on if the id is already set.
@@ -191,10 +192,11 @@ interface MyParcelComApiInterface
      *
      * @param string $resourceType
      * @param string $id
+     * @param int    $ttl
      * @return ResourceInterface
      * @throws MyParcelComException
      */
-    public function getResourceById($resourceType, $id);
+    public function getResourceById($resourceType, $id, $ttl = self::TTL_10MIN);
 
     /**
      * Get an array of all the resources from given uri.


### PR DESCRIPTION
# Changes
TTL of cache can be passed to `getResourceById` which enables customization of the `getShipment` method too. With this PR the `getShipment` method will no longer automatically cache the retrieved shipment resource.

In addition, I added `$ttl` as a parameter (with default value set) on all get methods for all types of resources. This makes cache TTL configurable for all