### PR TITLE
🔼 Allowing symafony/cache version 4.0 and newer to be used as well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "ext-json": "*",
     "psr/http-message": "^1.0",
     "psr/simple-cache": "^1.0",
-    "symfony/cache": "^3.3",
+    "symfony/cache": "^3.3|^4.0",
     "guzzlehttp/psr7": "^1.0",
     "setasign/fpdi-fpdf": "^2.0",
     "php-http/discovery": "^1.5",


### PR DESCRIPTION
# Changes
The symfony/cache version wouldn't work in conjunction with packages that require newer version. That's I suggest to allow the 4.* family as well.