### PR TITLE
Support newer symfony cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,13 +5,13 @@
   "require": {
     "php": ">=5.6",
     "ext-json": "*",
+    "guzzlehttp/psr7": "^1.0",
+    "php-http/discovery": "^1.5",
+    "php-http/httplug": "^1.1",
     "psr/http-message": "^1.0",
     "psr/simple-cache": "^1.0",
-    "symfony/cache": "^3.3|^4.0",
-    "guzzlehttp/psr7": "^1.0",
-    "setasign/fpdi-fpdf": "^2.0",
-    "php-http/discovery": "^1.5",
-    "php-http/httplug": "^1.1"
+    "symfony/cache": "^3.3|^4.0|^5.0",
+    "setasign/fpdi-fpdf": "^2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7",

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # Install locales for terminal and php.
 RUN apt-get update \
@@ -13,7 +13,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 RUN apt-get update \
-    && apt-get install -y curl zip unzip software-properties-common gettext-base iproute \
+    && apt-get install -y curl zip unzip software-properties-common gettext-base iproute2 \
     && add-apt-repository -y ppa:ondrej/php \
     && apt-get update \
     && apt-get install -y php5.6-cli php5.6-xdebug php5.6-dom php5.6-mbstring php5.6-curl \

--- a/docker/php70/Dockerfile
+++ b/docker/php70/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # Install locales for terminal and php.
 RUN apt-get update \
@@ -13,7 +13,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 RUN apt-get update \
-    && apt-get install -y curl zip unzip software-properties-common gettext-base iproute \
+    && apt-get install -y curl zip unzip software-properties-common gettext-base iproute2 \
     && add-apt-repository -y ppa:ondrej/php \
     && apt-get update \
     && apt-get install -y php7.0-cli php7.0-xdebug php7.0-dom php7.0-mbstring php7.0-curl \

--- a/docker/php71/Dockerfile
+++ b/docker/php71/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # Install locales for terminal and php.
 RUN apt-get update \
@@ -13,7 +13,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 RUN apt-get update \
-    && apt-get install -y curl zip unzip software-properties-common gettext-base iproute \
+    && apt-get install -y curl zip unzip software-properties-common gettext-base iproute2 \
     && add-apt-repository -y ppa:ondrej/php \
     && apt-get update \
     && apt-get install -y php7.1-cli php7.1-xdebug php7.1-dom php7.1-mbstring php7.1-curl \

--- a/docker/php72/Dockerfile
+++ b/docker/php72/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # Install locales for terminal and php.
 RUN apt-get update \
@@ -13,7 +13,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 RUN apt-get update \
-    && apt-get install -y curl zip unzip software-properties-common gettext-base iproute \
+    && apt-get install -y curl zip unzip software-properties-common gettext-base iproute2 \
     && add-apt-repository -y ppa:ondrej/php \
     && apt-get update \
     && apt-get install -y php7.2-cli php7.2-xdebug php7.2-dom php7.2-mbstring php7.2-curl \


### PR DESCRIPTION
- Added `symfony/cache ^5.0` to support Laravel 7 projects.