### PR TITLE
♻️ Increase max resource limit from 30 to 100

### DIFF
--- a/src/Collection/ArrayCollection.php
+++ b/src/Collection/ArrayCollection.php
@@ -40,7 +40,7 @@ class ArrayCollection implements CollectionInterface
 
     /**
      * Retrieves the resources based on limit and offset.
-     * Max (and default) limit is 30.
+     * Default limit is 30, max limit is 100.
      *
      * @return ResourceInterface[]
      */
@@ -67,14 +67,14 @@ class ArrayCollection implements CollectionInterface
 
     /**
      * Sets the amount of resources to be retrieved by get().
-     * Max and default limit is 30.
+     * Default limit is 30, max limit is 100.
      *
      * @param int $limit
      * @return $this
      */
     public function limit($limit = 30)
     {
-        $this->limit = min(30, max(1, $limit));
+        $this->limit = min(100, max(1, $limit));
 
         return $this;
     }

--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -32,7 +32,7 @@ interface CollectionInterface extends Iterator
 
     /**
      * Sets the amount of resources to be retrieved by get().
-     * Max and default limit is 30.
+     * Default limit is 30, max limit is 100.
      *
      * @param int $limit
      * @return $this

--- a/tests/Unit/PromiseCollectionTest.php
+++ b/tests/Unit/PromiseCollectionTest.php
@@ -78,6 +78,18 @@ class PromiseCollectionTest extends TestCase
     }
 
     /** @test */
+    public function testMaxLimit()
+    {
+        $resources = $this->collection->offset(3)->limit(101)->get();
+        $this->assertCount(100, $resources);
+
+        array_walk($resources, function ($resource) {
+            $this->assertGreaterThanOrEqual(3, $resource->id);
+            $this->assertLessThanOrEqual(103, $resource->id);
+        });
+    }
+
+    /** @test */
     public function testCount()
     {
         $this->assertEquals(123, $this->collection->count());


### PR DESCRIPTION
Since our API endpoints are able to return 100 results, our SDK should be able to `->limit(100)` as well.