### PR TITLE
♻️ json_encode service region arrays

### DIFF
--- a/src/Resources/Proxy/ServiceProxy.php
+++ b/src/Resources/Proxy/ServiceProxy.php
@@ -231,6 +231,44 @@ class ServiceProxy implements ServiceInterface, ResourceProxyInterface
     }
 
     /**
+     * @param array $regions
+     * @return $this
+     */
+    public function setRegionsFrom(array $regions)
+    {
+        $this->getResource()->setRegionsFrom($regions);
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRegionsFrom()
+    {
+        return $this->getResource()->getRegionsFrom();
+    }
+
+    /**
+     * @param array $regions
+     * @return $this
+     */
+    public function setRegionsTo(array $regions)
+    {
+        $this->getResource()->setRegionsTo($regions);
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRegionsTo()
+    {
+        return $this->getResource()->getRegionsTo();
+    }
+
+    /**
      * @param bool $usesVolumetricWeight
      * @return $this
      */

--- a/src/Resources/Service.php
+++ b/src/Resources/Service.php
@@ -44,8 +44,8 @@ class Service implements ServiceInterface
         self::ATTRIBUTE_NAME            => null,
         self::ATTRIBUTE_CODE            => null,
         self::ATTRIBUTE_PACKAGE_TYPE    => null,
-        self::ATTRIBUTE_REGIONS_FROM    => null,
-        self::ATTRIBUTE_REGIONS_TO      => null,
+        self::ATTRIBUTE_REGIONS_FROM    => [],
+        self::ATTRIBUTE_REGIONS_TO      => [],
         self::ATTRIBUTE_TRANSIT_TIME    => [
             self::ATTRIBUTE_TRANSIT_TIME_MIN => null,
             self::ATTRIBUTE_TRANSIT_TIME_MAX => null,
@@ -262,6 +262,44 @@ class Service implements ServiceInterface
         $this->attributes[self::ATTRIBUTE_DELIVERY_METHOD] = $deliveryMethod;
 
         return $this;
+    }
+
+    /**
+     * @param array $regions
+     * @return $this
+     */
+    public function setRegionsFrom(array $regions)
+    {
+        $this->attributes[self::ATTRIBUTE_REGIONS_FROM] = $regions;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRegionsFrom()
+    {
+        return $this->attributes[self::ATTRIBUTE_REGIONS_FROM];
+    }
+
+    /**
+     * @param array $regions
+     * @return $this
+     */
+    public function setRegionsTo(array $regions)
+    {
+        $this->attributes[self::ATTRIBUTE_REGIONS_TO] = $regions;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRegionsTo()
+    {
+        return $this->attributes[self::ATTRIBUTE_REGIONS_TO];
     }
 
     /**

--- a/tests/Feature/ResourceFactoryTest.php
+++ b/tests/Feature/ResourceFactoryTest.php
@@ -262,6 +262,7 @@ class ResourceFactoryTest extends TestCase
             'type'          => 'services',
             'attributes'    => [
                 'name'                   => 'Easy Delivery Service',
+                'code'                   => 'easy-service',
                 'package_type'           => ServiceInterface::PACKAGE_TYPE_PARCEL,
                 'transit_time'           => [
                     'min' => 2,
@@ -274,6 +275,17 @@ class ResourceFactoryTest extends TestCase
                     'Friday',
                 ],
                 'delivery_method'        => 'delivery',
+                'regions_from'           => [
+                    [
+                        'country_code' => 'GB',
+                    ],
+                ],
+                'regions_to'             => [
+                    [
+                        'country_code' => 'GB',
+                        'postal_code'  => '^((GY|JE).*|TR2[1-5]) ?[0-9]{1}[A-Z]{2}$',
+                    ],
+                ],
                 'uses_volumetric_weight' => true,
             ],
             'relationships' => [

--- a/tests/Stubs/get/https---api-service-rates/filter-has_active_contract--true/filter-weight--500/filter-service--a3057e77-005b-4945-a41c-20ddbe4dab08/filter-organization--org-id/include-contract,service/page-number--1/page-size--100.json
+++ b/tests/Stubs/get/https---api-service-rates/filter-has_active_contract--true/filter-weight--500/filter-service--a3057e77-005b-4945-a41c-20ddbe4dab08/filter-organization--org-id/include-contract,service/page-number--1/page-size--100.json
@@ -287,14 +287,13 @@
         "delivery_method": "delivery",
         "regions_from": [
           {
-            "country_code": "GB",
-            "region_code": "NIR"
+            "country_code": "GB"
           }
         ],
         "regions_to": [
           {
             "country_code": "GB",
-            "region_code": "NIR"
+            "postal_code": "^((GY|JE).*|TR2[1-5]) ?[0-9]{1}[A-Z]{2}$"
           }
         ],
         "uses_volumetric_weight": true

--- a/tests/Stubs/get/https---api-service-rates/filter-has_active_contract--true/filter-weight--500/filter-volumetric_weight--12800/filter-service--a3057e77-005b-4945-a41c-20ddbe4dab08/include-contract,service/page-number--1/page-size--100.json
+++ b/tests/Stubs/get/https---api-service-rates/filter-has_active_contract--true/filter-weight--500/filter-volumetric_weight--12800/filter-service--a3057e77-005b-4945-a41c-20ddbe4dab08/include-contract,service/page-number--1/page-size--100.json
@@ -191,14 +191,13 @@
         "delivery_method": "delivery",
         "regions_from": [
           {
-            "country_code": "GB",
-            "region_code": "NIR"
+            "country_code": "GB"
           }
         ],
         "regions_to": [
           {
             "country_code": "GB",
-            "region_code": "NIR"
+            "postal_code": "^((GY|JE).*|TR2[1-5]) ?[0-9]{1}[A-Z]{2}$"
           }
         ],
         "uses_volumetric_weight": true

--- a/tests/Stubs/get/https---api-services-433285bb-2e34-435c-9109-1120e7c4bce4.json
+++ b/tests/Stubs/get/https---api-services-433285bb-2e34-435c-9109-1120e7c4bce4.json
@@ -20,14 +20,13 @@
       "delivery_method": "delivery",
       "regions_from": [
         {
-          "country_code": "GB",
-          "region_code": "NIR"
+          "country_code": "GB"
         }
       ],
       "regions_to": [
         {
           "country_code": "GB",
-          "region_code": "NIR"
+          "postal_code": "^((GY|JE).*|TR2[1-5]) ?[0-9]{1}[A-Z]{2}$"
         }
       ],
       "uses_volumetric_weight": false

--- a/tests/Stubs/get/https---api-services/filter-has_active_contract--true/filter-address_from--country_code--GB/filter-address_from--postal_code--1AA BB2/filter-address_to--country_code--GB/filter-address_to--postal_code--B48 7QN.json
+++ b/tests/Stubs/get/https---api-services/filter-has_active_contract--true/filter-address_from--country_code--GB/filter-address_from--postal_code--1AA BB2/filter-address_to--country_code--GB/filter-address_to--postal_code--B48 7QN.json
@@ -20,14 +20,13 @@
         "delivery_method": "delivery",
         "regions_from": [
           {
-            "country_code": "GB",
-            "region_code": "NIR"
+            "country_code": "GB"
           }
         ],
         "regions_to": [
           {
             "country_code": "GB",
-            "region_code": "NIR"
+            "postal_code": "^((GY|JE).*|TR2[1-5]) ?[0-9]{1}[A-Z]{2}$"
           }
         ],
         "uses_volumetric_weight": true

--- a/tests/Stubs/get/https---api-services/filter-has_active_contract--true/filter-address_from--country_code--GB/filter-address_from--postal_code--1AA BB2/filter-address_to--country_code--GB/filter-address_to--postal_code--W8 6UX.json
+++ b/tests/Stubs/get/https---api-services/filter-has_active_contract--true/filter-address_from--country_code--GB/filter-address_from--postal_code--1AA BB2/filter-address_to--country_code--GB/filter-address_to--postal_code--W8 6UX.json
@@ -20,14 +20,13 @@
         "delivery_method": "delivery",
         "regions_from": [
           {
-            "country_code": "GB",
-            "region_code": "NIR"
+            "country_code": "GB"
           }
         ],
         "regions_to": [
           {
             "country_code": "GB",
-            "region_code": "NIR"
+            "postal_code": "^((GY|JE).*|TR2[1-5]) ?[0-9]{1}[A-Z]{2}$"
           }
         ],
         "uses_volumetric_weight": true

--- a/tests/Stubs/get/https---api-services/filter-has_active_contract--true/filter-carrier--eef00b32-177e-43d3-9b26-715365e4ce46/page-number--1/page-size--100.json
+++ b/tests/Stubs/get/https---api-services/filter-has_active_contract--true/filter-carrier--eef00b32-177e-43d3-9b26-715365e4ce46/page-number--1/page-size--100.json
@@ -20,14 +20,13 @@
         "delivery_method": "delivery",
         "regions_from": [
           {
-            "country_code": "GB",
-            "region_code": "NIR"
+            "country_code": "GB"
           }
         ],
         "regions_to": [
           {
             "country_code": "GB",
-            "region_code": "NIR"
+            "postal_code": "^((GY|JE).*|TR2[1-5]) ?[0-9]{1}[A-Z]{2}$"
           }
         ],
         "uses_volumetric_weight": true

--- a/tests/Stubs/get/https---api-services/filter-has_active_contract--true/filter-delivery_method--pick-up/filter-carrier--eef00b32-177e-43d3-9b26-715365e4ce46/page-number--1/page-size--100.json
+++ b/tests/Stubs/get/https---api-services/filter-has_active_contract--true/filter-delivery_method--pick-up/filter-carrier--eef00b32-177e-43d3-9b26-715365e4ce46/page-number--1/page-size--100.json
@@ -22,14 +22,13 @@
         "delivery_method": "pick-up",
         "regions_from": [
           {
-            "country_code": "GB",
-            "region_code": "NIR"
+            "country_code": "GB"
           }
         ],
         "regions_to": [
           {
             "country_code": "GB",
-            "region_code": "NIR"
+            "postal_code": "^((GY|JE).*|TR2[1-5]) ?[0-9]{1}[A-Z]{2}$"
           }
         ],
         "uses_volumetric_weight": false

--- a/tests/Stubs/get/https---api-services/filter-has_active_contract--true/filter-delivery_method--pick-up/page-number--1/page-size--100.json
+++ b/tests/Stubs/get/https---api-services/filter-has_active_contract--true/filter-delivery_method--pick-up/page-number--1/page-size--100.json
@@ -22,14 +22,13 @@
         "delivery_method": "pick-up",
         "regions_from": [
           {
-            "country_code": "GB",
-            "region_code": "NIR"
+            "country_code": "GB"
           }
         ],
         "regions_to": [
           {
             "country_code": "GB",
-            "region_code": "NIR"
+            "postal_code": "^((GY|JE).*|TR2[1-5]) ?[0-9]{1}[A-Z]{2}$"
           }
         ],
         "uses_volumetric_weight": false

--- a/tests/Stubs/get/https---api-services/filter-has_active_contract--true/page-number--1/page-size--100.json
+++ b/tests/Stubs/get/https---api-services/filter-has_active_contract--true/page-number--1/page-size--100.json
@@ -20,14 +20,13 @@
         "delivery_method": "delivery",
         "regions_from": [
           {
-            "country_code": "GB",
-            "region_code": "NIR"
+            "country_code": "GB"
           }
         ],
         "regions_to": [
           {
             "country_code": "GB",
-            "region_code": "NIR"
+            "postal_code": "^((GY|JE).*|TR2[1-5]) ?[0-9]{1}[A-Z]{2}$"
           }
         ],
         "uses_volumetric_weight": true
@@ -69,14 +68,13 @@
         "delivery_method": "delivery",
         "regions_from": [
           {
-            "country_code": "GB",
-            "region_code": "NIR"
+            "country_code": "GB"
           }
         ],
         "regions_to": [
           {
             "country_code": "GB",
-            "region_code": "NIR"
+            "postal_code": "^((GY|JE).*|TR2[1-5]) ?[0-9]{1}[A-Z]{2}$"
           }
         ],
         "uses_volumetric_weight": false
@@ -119,14 +117,13 @@
         "delivery_method": "delivery",
         "regions_from": [
           {
-            "country_code": "GB",
-            "region_code": "NIR"
+            "country_code": "GB"
           }
         ],
         "regions_to": [
           {
             "country_code": "GB",
-            "region_code": "NIR"
+            "postal_code": "^((GY|JE).*|TR2[1-5]) ?[0-9]{1}[A-Z]{2}$"
           }
         ],
         "uses_volumetric_weight": true

--- a/tests/Unit/ServiceTest.php
+++ b/tests/Unit/ServiceTest.php
@@ -161,6 +161,17 @@ class ServiceTest extends TestCase
             ->setHandoverMethod('drop-off')
             ->setDeliveryDays(['Monday'])
             ->setCarrier($carrier)
+            ->setRegionsFrom([
+                [
+                    'country_code' => 'GB',
+                ],
+            ])
+            ->setRegionsTo([
+                [
+                    'country_code' => 'GB',
+                    'postal_code'  => '^((GY|JE).*|TR2[1-5]) ?[0-9]{1}[A-Z]{2}$',
+                ],
+            ])
             ->setUsesVolumetricWeight(true);
 
         $this->assertEquals([
@@ -176,6 +187,17 @@ class ServiceTest extends TestCase
                 'handover_method'        => 'drop-off',
                 'delivery_days'          => [
                     'Monday',
+                ],
+                'regions_from'           => [
+                    [
+                        'country_code' => 'GB',
+                    ],
+                ],
+                'regions_to'             => [
+                    [
+                        'country_code' => 'GB',
+                        'postal_code'  => '^((GY|JE).*|TR2[1-5]) ?[0-9]{1}[A-Z]{2}$',
+                    ],
                 ],
                 'uses_volumetric_weight' => true,
             ],


### PR DESCRIPTION
A client reported it does not see the difference between multiple returned services.
The difference is in the regions_from and regions_to, but these values are not set / present in the output.