### PR TITLE
🧑‍💻 Check if value is an object or class before calling method_exists()

### DIFF
--- a/src/Resources/Traits/JsonSerializable.php
+++ b/src/Resources/Traits/JsonSerializable.php
@@ -75,12 +75,13 @@ trait JsonSerializable
         $array = [];
         foreach ($arrayValues as $key => $value) {
             $key = StringUtils::camelToSnakeCase($key);
+            $isObjectOrClass = is_object($value) || (is_string($value) && class_exists($value));
 
             if (is_scalar($value)) {
                 $array[$key] = $value;
             } elseif (is_array($value)) {
                 $array[$key] = $this->arrayValuesToArray($value);
-            } elseif (method_exists($value, 'jsonSerialize')) {
+            } elseif ($isObjectOrClass && method_exists($value, 'jsonSerialize')) {
                 $array[$key] = $value->jsonSerialize();
             }
         }


### PR DESCRIPTION
This PR implements the `is_object()` suggestion from https://github.com/MyParcelCOM/api-sdk-php/pull/170 including a check for a class path.

This check is added because the signature of `method_exists()` allows for objects or class paths:
```php
method_exists(object|string $object_or_class, string $method): bool
```