### PR TITLE
⚖️ Support weight brackets on ServiceRates

### DIFF
--- a/src/MyParcelComApi.php
+++ b/src/MyParcelComApi.php
@@ -387,6 +387,7 @@ class MyParcelComApi implements MyParcelComApiInterface
         $availableServiceRates = [];
         foreach ($serviceRates as $serviceRate) {
             if ($serviceRate->isDynamic()) {
+                // Resolve the price and currency for service-rates with a dynamic price.
                 try {
                     $serviceRates = $this->resolveDynamicServiceRates($shipment, $serviceRate);
 
@@ -399,6 +400,11 @@ class MyParcelComApi implements MyParcelComApiInterface
                 } catch (RequestException $exception) {
                     // If communicating with the carrier does not result in a service rate, this service is unavailable.
                 }
+            } elseif ($serviceRate->getBracketPrice()) {
+                // Resolve the price and currency for service-rates with a bracket price (calculated by the API).
+                $serviceRate->setPrice($serviceRate->getBracketPrice());
+                $serviceRate->setCurrency($serviceRate->getBracketCurrency());
+                $availableServiceRates[] = $serviceRate;
             } else {
                 $availableServiceRates[] = $serviceRate;
             }

--- a/src/Resources/Interfaces/ServiceRateInterface.php
+++ b/src/Resources/Interfaces/ServiceRateInterface.php
@@ -27,6 +27,22 @@ interface ServiceRateInterface extends ResourceInterface
     public function getWeightMax();
 
     /**
+     * @param array $weightBracket
+     */
+    public function setWeightBracket($weightBracket);
+
+    /**
+     * @return array
+     */
+    public function getWeightBracket();
+
+    /**
+     * @param int $weight
+     * @return int|null
+     */
+    public function calculateBracketPrice($weight);
+
+    /**
      * @param int $lengthMax
      * @return $this
      */

--- a/src/Resources/ResourceFactory.php
+++ b/src/Resources/ResourceFactory.php
@@ -303,6 +303,13 @@ class ResourceFactory implements ResourceFactoryInterface, ResourceProxyInterfac
             unset($properties['relationships']['service_options']);
         }
 
+        if (isset($properties['meta']['bracket_price']['amount'])) {
+            $serviceRate->setBracketPrice($properties['meta']['bracket_price']['amount']);
+            $serviceRate->setBracketCurrency($properties['meta']['bracket_price']['currency']);
+
+            unset($properties['meta']['bracket_price']);
+        }
+
         if (isset($properties['id'])) {
             $serviceRate->setResolveDynamicRateForShipmentCallback(function (ShipmentInterface $shipment, ServiceRateInterface $serviceRate) {
                 $serviceRates = $this->api->resolveDynamicServiceRates($shipment, $serviceRate);

--- a/src/Shipments/PriceCalculator.php
+++ b/src/Shipments/PriceCalculator.php
@@ -36,6 +36,18 @@ class PriceCalculator
             );
         }
 
+        if ($serviceRate->getPrice() === null && !empty($serviceRate->getWeightBracket())) {
+            $bracketPrice = $serviceRate->getBracketPrice()
+                ? $serviceRate->getBracketPrice()
+                : $serviceRate->calculateBracketPrice($shipment->getPhysicalProperties()->getWeight());
+            $bracketCurrency = $serviceRate->getBracketCurrency()
+                ? $serviceRate->getBracketCurrency()
+                : $serviceRate->getContract()->getCurrency();
+
+            $serviceRate->setPrice($bracketPrice);
+            $serviceRate->setCurrency($bracketCurrency);
+        }
+
         $serviceRatePrice = $serviceRate->getPrice();
         $fuelSurchargePrice = $serviceRate->getFuelSurchargeAmount() ?: 0;
         $serviceOptionPrice = $this->calculateOptionsPrice($shipment, $serviceRate);

--- a/tests/Stubs/get/https---api-service-rates/filter-has_active_contract--true/filter-weight--9000/filter-service--e097a359-5e05-465c-a75f-42ed5ed799e6/filter-organization--org-id/include-contract,service/page-number--1/page-size--100.json
+++ b/tests/Stubs/get/https---api-service-rates/filter-has_active_contract--true/filter-weight--9000/filter-service--e097a359-5e05-465c-a75f-42ed5ed799e6/filter-organization--org-id/include-contract,service/page-number--1/page-size--100.json
@@ -1,0 +1,130 @@
+{
+  "data": [
+    {
+      "id": "dee71cb4-1a21-48eb-adde-ebca98bd24fe",
+      "type": "service-rates",
+      "attributes": {
+        "weight_min": 0,
+        "weight_max": 30000,
+        "weight_bracket": {
+          "start": 6000,
+          "start_amount": 500,
+          "size": 1000,
+          "size_amount": 50
+        }
+      },
+      "links": {
+        "self": "https://api/service-rates/dee71cb4-1a21-48eb-adde-ebca98bd24fe"
+      },
+      "relationships": {
+        "service": {
+          "data": {
+            "id": "e097a359-5e05-465c-a75f-42ed5ed799e6",
+            "type": "services"
+          },
+          "links": {
+            "related": "https://api/services/e097a359-5e05-465c-a75f-42ed5ed799e6"
+          }
+        },
+        "contract": {
+          "data": {
+            "id": "f38b573e-35e1-41c8-a354-a2752898ef34",
+            "type": "contracts"
+          },
+          "links": {
+            "related": "https://api/contracts/f38b573e-35e1-41c8-a354-a2752898ef34"
+          }
+        }
+      },
+      "meta": {
+        "bracket_price": {
+          "amount": 9500,
+          "currency": "EUR"
+        }
+      }
+    }
+  ],
+  "meta": {
+    "total_pages": 1,
+    "total_records": 1
+  },
+  "included": [
+    {
+      "id": "f38b573e-35e1-41c8-a354-a2752898ef34",
+      "type": "contracts",
+      "attributes": {
+        "currency": "CAD",
+        "status": "active",
+        "name": "Contract Z",
+        "created_at": 1623395638,
+        "updated_at": 1623395669
+      },
+      "links": {
+        "self": "https://api/contracts/f38b573e-35e1-41c8-a354-a2752898ef34"
+      },
+      "relationships": {
+        "carrier": {
+          "data": {
+            "id": "eef00b32-177e-43d3-9b26-715365e4ce46",
+            "type": "carriers"
+          },
+          "links": {
+            "related": "https://api/carriers/eef00b32-177e-43d3-9b26-715365e4ce46"
+          }
+        },
+        "owner": {
+          "data": {
+            "id": "9056afa7-e88a-4c94-8a98-6cc124382112",
+            "type": "brokers"
+          },
+          "links": {
+            "related": "https://api/brokers/9056afa7-e88a-4c94-8a98-6cc124382112"
+          }
+        }
+      }
+    },
+    {
+      "id": "e097a359-5e05-465c-a75f-42ed5ed799e6",
+      "type": "services",
+      "attributes": {
+        "name": "Dynamic Test",
+        "code": "dynamic-test",
+        "package_type": "parcel",
+        "handover_method": "drop-off",
+        "delivery_method": "delivery",
+        "regions_from": [
+          {
+            "country_code": "GB"
+          }
+        ],
+        "regions_to": [
+          {
+            "country_code": "CA"
+          }
+        ],
+        "uses_volumetric_weight": false,
+        "strict_consolidation": false
+      },
+      "links": {
+        "self": "https://api/services/e097a359-5e05-465c-a75f-42ed5ed799e6",
+        "contracts": "https://api/services/e097a359-5e05-465c-a75f-42ed5ed799e6/contracts"
+      },
+      "relationships": {
+        "carrier": {
+          "links": {
+            "related": "https://api/carriers/eef00b32-177e-43d3-9b26-715365e4ce46"
+          },
+          "data": {
+            "id": "eef00b32-177e-43d3-9b26-715365e4ce46",
+            "type": "carriers"
+          }
+        }
+      }
+    }
+  ],
+  "links": {
+    "self": "https://api/service-rates?filter[has_active_contract]=true&filter[weight]=500&filter[service]=eef00b32-177e-43d3-9b26-715365e4ce46&page[size]=100&page[number]=1",
+    "first": "https://api/service-rates?filter[has_active_contract]=true&filter[weight]=500&filter[service]=eef00b32-177e-43d3-9b26-715365e4ce46&page[size]=100&page[number]=1",
+    "last": "https://api/service-rates?filter[has_active_contract]=true&filter[weight]=500&filter[service]=eef00b32-177e-43d3-9b26-715365e4ce46&page[size]=100&page[number]=1"
+  }
+}

--- a/tests/Traits/MocksContract.php
+++ b/tests/Traits/MocksContract.php
@@ -56,6 +56,9 @@ trait MocksContract
             ->method('getWeightMax')
             ->willReturn($weightMax);
         $mock
+            ->method('getWeightBracket')
+            ->willReturn([]);
+        $mock
             ->method('isDynamic')
             ->willReturn($isDynamic);
         $mock

--- a/tests/Unit/ServiceRateTest.php
+++ b/tests/Unit/ServiceRateTest.php
@@ -147,10 +147,17 @@ class ServiceRateTest extends TestCase
             ->setId('service-rate-id')
             ->setWeightMin(123)
             ->setWeightMax(456)
+            ->setWeightBracket([
+                'start'        => 200,
+                'start_amount' => 500,
+                'size'         => 100,
+                'size_amount'  => 123,
+            ])
             ->setLengthMax(789)
             ->setWidthMax(987)
             ->setHeightMax(654)
             ->setVolumeMax(321)
+            ->setVolumetricWeightDivisor(5000)
             ->setCurrency('GBP')
             ->setPrice(741)
             ->setFuelSurchargeAmount(19)
@@ -168,21 +175,28 @@ class ServiceRateTest extends TestCase
             'id'            => 'service-rate-id',
             'type'          => 'service-rates',
             'attributes'    => [
-                'price'          => [
+                'price'                     => [
                     'amount'   => 741,
                     'currency' => 'GBP',
                 ],
-                'fuel_surcharge' => [
+                'fuel_surcharge'            => [
                     'amount'   => 19,
                     'currency' => 'GBP',
                 ],
-                'weight_min'     => 123,
-                'weight_max'     => 456,
-                'length_max'     => 789,
-                'width_max'      => 987,
-                'height_max'     => 654,
-                'volume_max'     => 321,
-                'is_dynamic'     => false,
+                'weight_min'                => 123,
+                'weight_max'                => 456,
+                'weight_bracket'            => [
+                    'start'        => 200,
+                    'start_amount' => 500,
+                    'size'         => 100,
+                    'size_amount'  => 123,
+                ],
+                'length_max'                => 789,
+                'width_max'                 => 987,
+                'height_max'                => 654,
+                'volume_max'                => 321,
+                'volumetric_weight_divisor' => 5000,
+                'is_dynamic'                => false,
             ],
             'relationships' => [
                 'service'         => [


### PR DESCRIPTION
https://myparcelcombv.atlassian.net/browse/MP-5700
---
- Add `weight_bracket` and `bracket_price` to the `ServiceRate` model.
- Use the bracket price in the `getServiceRatesForShipment()` function.
- Use the weight bracket in the `PriceCalculator` class.