### PR TITLE
👷 Fix CI badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Tests
 on: push
 jobs:
   php56:
@@ -6,13 +6,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
       - name: Composer
         uses: php-actions/composer@v6
         with:
           version: 2.2.x
           php_version: 5.6
-
       - name: PHPUnit
         uses: php-actions/phpunit@v3
         with:
@@ -24,13 +22,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
       - name: Composer
         uses: php-actions/composer@v6
         with:
           version: 2.2.x
           php_version: 7.0
-
       - name: PHPUnit
         uses: php-actions/phpunit@v3
         with:
@@ -42,13 +38,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
       - name: Composer
         uses: php-actions/composer@v6
         with:
           version: 2.2.x
           php_version: 7.1
-
       - name: PHPUnit
         uses: php-actions/phpunit@v3
         with:
@@ -60,12 +54,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
       - name: Composer
         uses: php-actions/composer@v6
         with:
           php_version: 7.2
-
       - name: PHPUnit
         uses: php-actions/phpunit@v3
         with:
@@ -77,12 +69,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
       - name: Composer
         uses: php-actions/composer@v6
         with:
           php_version: 7.3
-
       - name: PHPUnit
         uses: php-actions/phpunit@v3
         with:
@@ -94,12 +84,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
       - name: Composer
         uses: php-actions/composer@v6
         with:
           php_version: 7.4
-
       - name: PHPUnit
         uses: php-actions/phpunit@v3
         with:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # MyParcel.com SDK
 
 [![Packagist](https://img.shields.io/packagist/v/myparcelcom/api-sdk.svg)](https://packagist.org/packages/myparcelcom/api-sdk)
-[![CircleCI](https://circleci.com/gh/MyParcelCOM/api-sdk-php/tree/master.svg?style=shield&circle-token=3a7a34cbcf9252d53e0fd749dc4fd22e09b04f4b)](https://circleci.com/gh/MyParcelCOM/api-sdk-php)
+[![GitHub Actions](https://github.com/myparcelcom/api-sdk-php/actions/workflows/ci.yml/badge.svg)](https://github.com/myparcelcom/api-sdk-php/actions)
 
-The MyParcel.com SDK is a PHP library that can be used to easily communicate with the MyParcel.com API. For more information see the [MyParcel.com Docs](https://docs.myparcel.com/).
+The MyParcel.com SDK is a PHP library that can be used to easily communicate with the MyParcel.com API.
+For more information see the [MyParcel.com Docs](https://docs.myparcel.com/php-sdk.html).

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,7 +19,7 @@
         </whitelist>
     </filter>
     <logging>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>
     </logging>
     <php>


### PR DESCRIPTION
We no longer use CircleCI to run the tests, so the badge needs to point to GitHub Actions:

[![GitHub Actions](https://github.com/myparcelcom/api-sdk-php/actions/workflows/ci.yml/badge.svg)](https://github.com/myparcelcom/api-sdk-php/actions)