### PR TITLE
💥 PHP 8 features

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,5 +40,9 @@
     "allow-plugins": {
       "php-http/discovery": true
     }
+  },
+  "suggest": {
+    "php-http/guzzle7-adapter": "Install this package if Guzzle 7 is available in the application.",
+    "php-http/curl-client": "Install this package if Guzzle is not available in the application, but curl is."
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "php-http/httplug": ">=1.1",
     "psr/http-message": "^1.0",
     "psr/simple-cache": "^1.0",
-    "symfony/cache": ">=3.3",
+    "symfony/cache": ">=5.0",
     "setasign/fpdf": "^1.8",
     "setasign/fpdi": "^2.0"
   },

--- a/src/Authentication/AuthenticatorInterface.php
+++ b/src/Authentication/AuthenticatorInterface.php
@@ -15,13 +15,10 @@ interface AuthenticatorInterface
     const SCOPES = '*';
 
     /**
-     * Authenticate with the OAuth2 server and return the header to be used in
-     * requests to the API. When `$forceRefresh` is set to `true`, any possibly
-     * cached header is ignored and a new request is done to the auth server.
+     * Authenticate with the OAuth2 server and return the header to be used in requests to the API.
+     * When `$forceRefresh` is set to `true`, cache is ignored and a new request is done to the auth server.
      *
-     * @param bool $forceRefresh
-     * @return array
      * @throws AuthenticationException
      */
-    public function getAuthorizationHeader($forceRefresh = false);
+    public function getAuthorizationHeader(bool $forceRefresh = false): array;
 }

--- a/src/Authentication/AuthenticatorInterface.php
+++ b/src/Authentication/AuthenticatorInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Authentication;
 
 use MyParcelCom\ApiSdk\Exceptions\AuthenticationException;

--- a/src/Authentication/ClientCredentials.php
+++ b/src/Authentication/ClientCredentials.php
@@ -12,7 +12,6 @@ use Psr\Http\Client\ClientInterface;
 use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Psr16Cache;
-use Symfony\Component\Cache\Simple\FilesystemCache;
 
 class ClientCredentials implements AuthenticatorInterface
 {
@@ -38,13 +37,8 @@ class ClientCredentials implements AuthenticatorInterface
     ) {
         // Either use the given cache or instantiate a new one that uses the filesystem temp directory as a cache.
         if (!$cache) {
-            // Symfony 5.0.0 removed their PSR-16 cache classes. Their PSR-6 cache classes can be wrapped in Psr16Cache.
-            if (class_exists('\Symfony\Component\Cache\Psr16Cache')) {
-                $psr6Cache = new FilesystemAdapter('myparcelcom');
-                $cache = new Psr16Cache($psr6Cache);
-            } else {
-                $cache = new FilesystemCache('myparcelcom');
-            }
+            $psr6Cache = new FilesystemAdapter('myparcelcom');
+            $cache = new Psr16Cache($psr6Cache);
         }
         $this->cache = $cache;
 

--- a/src/Authentication/ClientCredentials.php
+++ b/src/Authentication/ClientCredentials.php
@@ -3,10 +3,10 @@
 namespace MyParcelCom\ApiSdk\Authentication;
 
 use GuzzleHttp\Psr7\Request;
-use Http\Client\HttpClient;
 use Http\Discovery\HttpClientDiscovery;
 use MyParcelCom\ApiSdk\Exceptions\AuthenticationException;
 use MyParcelCom\ApiSdk\Http\Exceptions\RequestException;
+use Psr\Http\Client\ClientInterface;
 use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Psr16Cache;
@@ -19,44 +19,21 @@ class ClientCredentials implements AuthenticatorInterface
     const PATH_ACCESS_TOKEN = '/access-token';
     const TTL_MARGIN = 60;
 
-    /** @var string */
-    protected $clientSecret;
-
-    /** @var string */
-    protected $clientId;
-
-    /** @var string */
-    protected $authUri;
-
-    /** @var CacheInterface */
-    private $cache;
-
-    /** @var HttpClient */
-    private $httpClient;
+    private ?CacheInterface $cache = null;
+    private ?ClientInterface $httpClient = null;
 
     /**
-     * Create an authenticator for the client_credentials grant. Requires a
-     * client id and a client secret. When not connecting to the MyParcel.com
-     * sandbox, the `$authUri` should be set to the correct uri. Optionally a
-     * cache can be supplied to store the api-key in.
-     *
-     * @param string              $clientId
-     * @param string              $clientSecret
-     * @param string              $authUri
-     * @param CacheInterface|null $cache
-     * @param HttpClient|null     $httpClient
+     * Create an authenticator for the client_credentials grant. Requires a client id and a client secret. When not
+     * connecting to the MyParcel.com sandbox, the `$authUri` should be set to the correct uri. Optionally a cache can
+     * be supplied to store the api-key in.
      */
     public function __construct(
-        $clientId,
-        $clientSecret,
-        $authUri = 'https://sandbox-auth.myparcel.com',
-        CacheInterface $cache = null,
-        HttpClient $httpClient = null
+        protected string $clientId,
+        protected string $clientSecret,
+        protected string $authUri = 'https://sandbox-auth.myparcel.com',
+        ?CacheInterface $cache = null,
+        ?ClientInterface $httpClient = null
     ) {
-        $this->clientSecret = $clientSecret;
-        $this->clientId = $clientId;
-        $this->authUri = $authUri;
-
         // Either use the given cache or instantiate a new one that uses the filesystem temp directory as a cache.
         if (!$cache) {
             // Symfony 5.0.0 removed their PSR-16 cache classes. Their PSR-6 cache classes can be wrapped in Psr16Cache.
@@ -74,10 +51,7 @@ class ClientCredentials implements AuthenticatorInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getAuthorizationHeader($forceRefresh = false)
+    public function getAuthorizationHeader(bool $forceRefresh = false): array
     {
         while ($this->isAuthenticating()) {
             // Wait for 200ms
@@ -96,19 +70,13 @@ class ClientCredentials implements AuthenticatorInterface
 
     /**
      * Returns true if another request is already authenticating.
-     *
-     * @return bool
      */
-    protected function isAuthenticating()
+    protected function isAuthenticating(): bool
     {
         return (bool) $this->cache->get($this->cacheKey(self::CACHE_AUTHENTICATING));
     }
 
-    /**
-     * @param bool $authenticating
-     * @return $this
-     */
-    protected function setAuthenticating($authenticating = true)
+    protected function setAuthenticating(bool $authenticating = true): self
     {
         // Don't let the authenticating lock stay active for more than 30s.
         $this->cache->set($this->cacheKey(self::CACHE_AUTHENTICATING), $authenticating, 30);
@@ -118,10 +86,8 @@ class ClientCredentials implements AuthenticatorInterface
 
     /**
      * Authenticate with the server and return the header.
-     *
-     * @return array
      */
-    protected function authenticate()
+    protected function authenticate(): array
     {
         $this->setAuthenticating();
 
@@ -165,43 +131,31 @@ class ClientCredentials implements AuthenticatorInterface
 
     /**
      * Get the cached header or `null` if no header is cached (or expired).
-     *
-     * @return array|null
      */
-    protected function getCachedHeader()
+    protected function getCachedHeader(): ?array
     {
         return $this->cache->get($this->cacheKey(self::CACHE_TOKEN));
     }
 
     /**
      * Set the cached header with a time to live.
-     *
-     * @param array $header
-     * @param int   $ttl
-     * @return $this
      */
-    protected function setCachedHeader(array $header, $ttl)
+    protected function setCachedHeader(array $header, int $ttl): self
     {
         $this->cache->set($this->cacheKey(self::CACHE_TOKEN), $header, $ttl - self::TTL_MARGIN);
 
         return $this;
     }
 
-    /**
-     * @param string $cacheType
-     * @return string
-     */
-    protected function cacheKey($cacheType)
+    protected function cacheKey(string $cacheType): string
     {
         return implode('_', [$cacheType, $this->clientId]);
     }
 
     /**
      * Clear the cached resources.
-     *
-     * @return $this
      */
-    public function clearCache()
+    public function clearCache(): self
     {
         $this->cache->clear();
 
@@ -209,13 +163,9 @@ class ClientCredentials implements AuthenticatorInterface
     }
 
     /**
-     * Set the http client to use. This can be used when extra options need to
-     * be set on the client.
-     *
-     * @param HttpClient $client
-     * @return $this
+     * Set the http client to use. This can be used when extra options need to be set on the client.
      */
-    public function setHttpClient(HttpClient $client)
+    public function setHttpClient(ClientInterface $client): self
     {
         $this->httpClient = $client;
 
@@ -224,10 +174,8 @@ class ClientCredentials implements AuthenticatorInterface
 
     /**
      * Get the http client to connect to the auth server.
-     *
-     * @return HttpClient
      */
-    protected function getHttpClient()
+    protected function getHttpClient(): ClientInterface
     {
         if (!isset($this->httpClient)) {
             $this->httpClient = HttpClientDiscovery::find();
@@ -238,11 +186,8 @@ class ClientCredentials implements AuthenticatorInterface
 
     /**
      * Handle the request exception.
-     *
-     * @param RequestException $exception
-     * @return void
      */
-    protected function handleRequestException(RequestException $exception)
+    protected function handleRequestException(RequestException $exception): void
     {
         if (empty($exception->getResponse())) {
             throw new AuthenticationException(

--- a/src/Authentication/ClientCredentials.php
+++ b/src/Authentication/ClientCredentials.php
@@ -20,9 +20,6 @@ class ClientCredentials implements AuthenticatorInterface
     const PATH_ACCESS_TOKEN = '/access-token';
     const TTL_MARGIN = 60;
 
-    private ?CacheInterface $cache = null;
-    private ?ClientInterface $httpClient = null;
-
     /**
      * Create an authenticator for the client_credentials grant. Requires a client id and a client secret. When not
      * connecting to the MyParcel.com sandbox, the `$authUri` should be set to the correct uri. Optionally a cache can
@@ -32,18 +29,13 @@ class ClientCredentials implements AuthenticatorInterface
         protected string $clientId,
         protected string $clientSecret,
         protected string $authUri = 'https://sandbox-auth.myparcel.com',
-        ?CacheInterface $cache = null,
-        ?ClientInterface $httpClient = null
+        protected ?CacheInterface $cache = null,
+        protected ?ClientInterface $httpClient = null
     ) {
-        // Either use the given cache or instantiate a new one that uses the filesystem temp directory as a cache.
+        // If no cache is provided, instantiate a new one that uses the filesystem temp directory as a cache.
         if (!$cache) {
             $psr6Cache = new FilesystemAdapter('myparcelcom');
-            $cache = new Psr16Cache($psr6Cache);
-        }
-        $this->cache = $cache;
-
-        if ($httpClient !== null) {
-            $this->setHttpClient($httpClient);
+            $this->cache = new Psr16Cache($psr6Cache);
         }
     }
 

--- a/src/Authentication/ClientCredentials.php
+++ b/src/Authentication/ClientCredentials.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Authentication;
 
 use GuzzleHttp\Psr7\Request;
@@ -56,8 +58,7 @@ class ClientCredentials implements AuthenticatorInterface
         while ($this->isAuthenticating()) {
             // Wait for 200ms
             usleep(200000);
-            // Don't force another authentication cycle if we're already
-            // authenticating.
+            // Don't force another authentication cycle if we're already authenticating.
             $forceRefresh = false;
         }
 

--- a/src/Collection/ArrayCollection.php
+++ b/src/Collection/ArrayCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Collection;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\ResourceInterface;
@@ -7,20 +9,13 @@ use MyParcelCom\ApiSdk\Resources\Interfaces\ResourceInterface;
 class ArrayCollection implements CollectionInterface
 {
     /** @var ResourceInterface[] */
-    protected $resources;
+    protected array $resources = [];
 
-    /** @var int */
-    protected $offset = 0;
-
-    /** @var int */
-    protected $limit = 100;
-
-    /** @var int */
-    protected $currentResourceNumber = 0;
+    protected int $offset = 0;
+    protected int $limit = 100;
+    protected int $currentResourceNumber = 0;
 
     /**
-     * ArrayCollection constructor.
-     *
      * @param ResourceInterface[] $resources
      */
     public function __construct(array $resources)

--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Collection;
 
 use Iterator;

--- a/src/Collection/RequestCollection.php
+++ b/src/Collection/RequestCollection.php
@@ -83,7 +83,7 @@ class RequestCollection implements CollectionInterface
     {
         $response = call_user_func_array($this->promiseCreator, [$pageNumber, $this->limit]);
 
-        $body = json_decode($response->getBody(), true);
+        $body = json_decode((string) $response->getBody(), true);
 
         $this->count = $body['meta']['total_records'];
         $included = $body['included'] ?? null;

--- a/src/Collection/RequestCollection.php
+++ b/src/Collection/RequestCollection.php
@@ -56,8 +56,8 @@ class RequestCollection implements CollectionInterface
         // A maximum of 100 resources per page can be retrieved at once.
         // We need to specify which page should be retrieved from the api,
         // or which pages if the set offset and limit overlaps two pages.
-        $firstPage = ceil(($this->offset + 1) / $this->limit);
-        $secondPage = ceil(($this->offset + $this->limit) / $this->limit);
+        $firstPage = (int) ceil(($this->offset + 1) / $this->limit);
+        $secondPage = (int) ceil(($this->offset + $this->limit) / $this->limit);
 
         if (!isset($this->resources[$this->offset])) {
             $this->retrieveResources($firstPage);

--- a/src/Collection/RequestCollection.php
+++ b/src/Collection/RequestCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Collection;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\ResourceInterface;
@@ -13,26 +15,13 @@ class RequestCollection implements CollectionInterface
     protected $resourceCreator;
 
     /** @var ResourceInterface[] */
-    protected $resources = [];
+    protected array $resources = [];
 
-    /** @var int */
-    protected $offset = 0;
+    protected int $offset = 0;
+    protected int $limit = 100;
+    protected int $count;
+    protected int $currentResourceNumber = 0;
 
-    /** @var int */
-    protected $limit = 100;
-
-    /** @var int */
-    protected $count;
-
-    /** @var int */
-    protected $currentResourceNumber = 0;
-
-    /**
-     * PromiseCollection constructor.
-     *
-     * @param callable $promiseCreator
-     * @param callable $resourceCreator
-     */
     public function __construct(callable $promiseCreator, callable $resourceCreator)
     {
         $this->promiseCreator = $promiseCreator;
@@ -88,8 +77,7 @@ class RequestCollection implements CollectionInterface
     }
 
     /**
-     * Retrieve the resources for the given page number and store them
-     * in this->resources according to their number.
+     * Retrieve the resources for the given page number and store them in this->resources according to their number.
      */
     private function retrieveResources(int $pageNumber): void
     {
@@ -98,7 +86,7 @@ class RequestCollection implements CollectionInterface
         $body = json_decode($response->getBody(), true);
 
         $this->count = $body['meta']['total_records'];
-        $included = isset($body['included']) ? $body['included'] : null;
+        $included = $body['included'] ?? null;
         $resources = call_user_func($this->resourceCreator, $body['data'], $included);
 
         $resourceNumber = ($pageNumber - 1) * $this->limit;

--- a/src/Enums/TaxTypeEnum.php
+++ b/src/Enums/TaxTypeEnum.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Enums;
 
 use MyCLabs\Enum\Enum;

--- a/src/Enums/WeightUnitEnum.php
+++ b/src/Enums/WeightUnitEnum.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Enums;
 
 use MyCLabs\Enum\Enum;

--- a/src/Exceptions/AuthenticationException.php
+++ b/src/Exceptions/AuthenticationException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Exceptions;
 
 /**
@@ -7,5 +9,4 @@ namespace MyParcelCom\ApiSdk\Exceptions;
  */
 class AuthenticationException extends MyParcelComException
 {
-
 }

--- a/src/Exceptions/CalculationException.php
+++ b/src/Exceptions/CalculationException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Exceptions;
 
 /**
@@ -7,5 +9,4 @@ namespace MyParcelCom\ApiSdk\Exceptions;
  */
 class CalculationException extends MyParcelComException
 {
-
 }

--- a/src/Exceptions/ConnectionException.php
+++ b/src/Exceptions/ConnectionException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Exceptions;
 
 /**
@@ -7,5 +9,4 @@ namespace MyParcelCom\ApiSdk\Exceptions;
  */
 class ConnectionException extends MyParcelComException
 {
-
 }

--- a/src/Exceptions/ConversionException.php
+++ b/src/Exceptions/ConversionException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Exceptions;
 
 /**
@@ -7,5 +9,4 @@ namespace MyParcelCom\ApiSdk\Exceptions;
  */
 class ConversionException extends MyParcelComException
 {
-
 }

--- a/src/Exceptions/InvalidResourceException.php
+++ b/src/Exceptions/InvalidResourceException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Exceptions;
 
 /**
@@ -7,5 +9,4 @@ namespace MyParcelCom\ApiSdk\Exceptions;
  */
 class InvalidResourceException extends MyParcelComException
 {
-
 }

--- a/src/Exceptions/LabelCombinerException.php
+++ b/src/Exceptions/LabelCombinerException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Exceptions;
 
 /**
@@ -7,5 +9,4 @@ namespace MyParcelCom\ApiSdk\Exceptions;
  */
 class LabelCombinerException extends MyParcelComException
 {
-
 }

--- a/src/Exceptions/MyParcelComException.php
+++ b/src/Exceptions/MyParcelComException.php
@@ -1,17 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Exceptions;
 
 use MyParcelCom\ApiSdk\Traits\HasErrors;
 use RuntimeException;
 
 /**
- * This exception is thrown whenever a request to the API fails. This can be
- * because the API is unreachable, authentication has failed, invalid resources
- * are sent or received, etc.
+ * This exception is thrown whenever a request to the API fails. This can be because the API is unreachable,
+ * authentication has failed, invalid resources are sent or received, etc.
  *
- * In general each of these exceptions are thrown with an exception that extends
- * this exception.
+ * In general each of these exceptions are thrown with an exception that extends this exception.
  */
 class MyParcelComException extends RuntimeException
 {

--- a/src/Exceptions/ResourceFactoryException.php
+++ b/src/Exceptions/ResourceFactoryException.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Exceptions;
 
 /**
- * This exception is thrown by the ResourceFactory, when a resource cannot be
- * instantiated.
+ * This exception is thrown by the ResourceFactory, when a resource cannot be instantiated.
  */
 class ResourceFactoryException extends MyParcelComException
 {
-
 }

--- a/src/Exceptions/ResourceNotFoundException.php
+++ b/src/Exceptions/ResourceNotFoundException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Exceptions;
 
 /**
@@ -7,5 +9,4 @@ namespace MyParcelCom\ApiSdk\Exceptions;
  */
 class ResourceNotFoundException extends MyParcelComException
 {
-
 }

--- a/src/Exceptions/ServiceMatchingException.php
+++ b/src/Exceptions/ServiceMatchingException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Exceptions;
 
 /**
@@ -8,5 +10,4 @@ namespace MyParcelCom\ApiSdk\Exceptions;
  */
 class ServiceMatchingException extends MyParcelComException
 {
-
 }

--- a/src/Helpers/WeightConverter.php
+++ b/src/Helpers/WeightConverter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Helpers;
 
 use MyParcelCom\ApiSdk\Enums\WeightUnitEnum;
@@ -7,62 +9,34 @@ use MyParcelCom\ApiSdk\Exceptions\MyParcelComException;
 
 class WeightConverter
 {
-    /**
-     * @param float|int $weight
-     * @param string    $from
-     * @param string    $to
-     * @return int|float
-     */
-    public static function convert($weight, $from, $to)
+    public static function convert(float|int $weight, string $from, string $to): float|int
     {
         $weightInGrams = self::convertToGrams($weight, $from);
 
         return self::convertFromGrams($weightInGrams, $to);
     }
 
-    /**
-     * @param float|int $weight
-     * @param string    $from
-     * @return int|float
-     */
-    private static function convertToGrams($weight, $from)
+    private static function convertToGrams(float|int $weight, string $from): float|int
     {
-        switch ($from) {
-            case WeightUnitEnum::MILLIGRAM:
-                return $weight / 1000;
-            case WeightUnitEnum::GRAM:
-                return $weight;
-            case WeightUnitEnum::KILOGRAM:
-                return $weight * 1000;
-            case WeightUnitEnum::OUNCE:
-                return $weight * 28.3495;
-            case WeightUnitEnum::POUND:
-                return $weight * 453.592;
-            default:
-                throw new MyParcelComException('Invalid weight unit');
-        }
+        return match ($from) {
+            WeightUnitEnum::MILLIGRAM => $weight / 1000,
+            WeightUnitEnum::GRAM => $weight,
+            WeightUnitEnum::KILOGRAM => $weight * 1000,
+            WeightUnitEnum::OUNCE => $weight * 28.3495,
+            WeightUnitEnum::POUND => $weight * 453.592,
+            default => throw new MyParcelComException('Invalid weight unit'),
+        };
     }
 
-    /**
-     * @param float|int $weightInGrams
-     * @param string    $to
-     * @return float|int
-     */
-    private static function convertFromGrams($weightInGrams, $to)
+    private static function convertFromGrams(float|int $weightInGrams, string $to): float|int
     {
-        switch ($to) {
-            case WeightUnitEnum::MILLIGRAM:
-                return $weightInGrams * 1000;
-            case WeightUnitEnum::GRAM:
-                return $weightInGrams;
-            case WeightUnitEnum::KILOGRAM:
-                return $weightInGrams / 1000;
-            case WeightUnitEnum::OUNCE:
-                return $weightInGrams / 28.3495;
-            case WeightUnitEnum::POUND:
-                return $weightInGrams / 453.592;
-            default:
-                throw new MyParcelComException('Invalid weight unit');
-        }
+        return match ($to) {
+            WeightUnitEnum::MILLIGRAM => $weightInGrams * 1000,
+            WeightUnitEnum::GRAM => $weightInGrams,
+            WeightUnitEnum::KILOGRAM => $weightInGrams / 1000,
+            WeightUnitEnum::OUNCE => $weightInGrams / 28.3495,
+            WeightUnitEnum::POUND => $weightInGrams / 453.592,
+            default => throw new MyParcelComException('Invalid weight unit'),
+        };
     }
 }

--- a/src/Http/Contracts/HttpClient/RequestExceptionInterface.php
+++ b/src/Http/Contracts/HttpClient/RequestExceptionInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Http\Contracts\HttpClient;
 
 use Psr\Http\Message\RequestInterface;
@@ -18,17 +20,13 @@ interface RequestExceptionInterface
      * Returns the request.
      *
      * The request object MAY be a different object from the one passed to ClientInterface::sendRequest()
-     *
-     * @return RequestInterface
      */
-    public function getRequest();
+    public function getRequest(): RequestInterface;
 
     /**
      * Returns the response of the failed request.
      *
      * May return null if there was no response.
-     *
-     * @return ResponseInterface|null
      */
-    public function getResponse();
+    public function getResponse(): ?ResponseInterface;
 }

--- a/src/Http/Exceptions/RequestException.php
+++ b/src/Http/Exceptions/RequestException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Http\Exceptions;
 
 use Exception;
@@ -10,22 +12,11 @@ use Throwable;
 
 class RequestException extends Exception implements RequestExceptionInterface
 {
-    /** @var RequestInterface */
-    private $request;
-
-    /** @var ResponseInterface */
-    private $response;
-
-    /**
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     * @param Throwable|null    $previous
-     */
-    public function __construct(RequestInterface $request, ResponseInterface $response, Throwable $previous = null)
-    {
-        $this->request = $request;
-        $this->response = $response;
-
+    public function __construct(
+        private RequestInterface $request,
+        private ResponseInterface $response,
+        ?Throwable $previous = null,
+    ) {
         parent::__construct($response->getReasonPhrase(), $response->getStatusCode(), $previous);
     }
 
@@ -33,10 +24,8 @@ class RequestException extends Exception implements RequestExceptionInterface
      * Returns the request.
      *
      * The request object MAY be a different object from the one passed to ClientInterface::sendRequest()
-     *
-     * @return RequestInterface
      */
-    public function getRequest()
+    public function getRequest(): RequestInterface
     {
         return $this->request;
     }
@@ -45,10 +34,8 @@ class RequestException extends Exception implements RequestExceptionInterface
      * Returns the response of the failed request.
      *
      * May return null if there was no response.
-     *
-     * @return ResponseInterface|null
      */
-    public function getResponse()
+    public function getResponse(): ?ResponseInterface
     {
         return $this->response;
     }

--- a/src/LabelCombiner.php
+++ b/src/LabelCombiner.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk;
 
 use MyParcelCom\ApiSdk\Exceptions\LabelCombinerException;

--- a/src/LabelCombiner.php
+++ b/src/LabelCombiner.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace MyParcelCom\ApiSdk;
 
 use MyParcelCom\ApiSdk\Exceptions\LabelCombinerException;
-use MyParcelCom\ApiSdk\Exceptions\MyParcelComException;
 use MyParcelCom\ApiSdk\Resources\File;
 use MyParcelCom\ApiSdk\Resources\Interfaces\FileInterface;
 use setasign\Fpdi\Fpdi;
@@ -15,40 +14,12 @@ class LabelCombiner implements LabelCombinerInterface
     const LABEL_WIDTH = 420.94;
     const LABEL_HEIGHT = 297.64;
 
-    /**
-     * Combines given labels into 1 file and returns it. When a starting
-     * location on the page is chosen, up to 3 locations will be left blank.
-     * This allows for re-using of label paper that has 1 or more labels
-     * already used.
-     *
-     * The following are the order of positions per page size:
-     *
-     * PAGE_SIZE_A4
-     * - LOCATION_TOP_LEFT
-     * - LOCATION_TOP_RIGHT
-     * - LOCATION_BOTTOM_LEFT
-     * - LOCATION_BOTTOM_RIGHT
-     *
-     * PAGE_SIZE_A5
-     * - LOCATION_TOP
-     * - LOCATION_BOTTOM
-     *
-     * PAGE_SIZE_A6
-     * - LOCATION_TOP
-     *
-     * @param FileInterface[] $files
-     * @param string          $pageSize
-     * @param int             $startLocation
-     * @param int             $margin
-     * @return FileInterface
-     * @throws MyParcelComException
-     */
     public function combineLabels(
         array $files,
-        $pageSize = self::PAGE_SIZE_A4,
-        $startLocation = self::LOCATION_TOP_LEFT,
-        $margin = 0
-    ) {
+        string $pageSize = self::PAGE_SIZE_A4,
+        int $startLocation = self::LOCATION_TOP_LEFT,
+        int $margin = 0
+    ): FileInterface {
         [$labelsPerRow, $labelsPerColumn] = $this->getLabelsPerPage($pageSize);
         $labelsPerPage = $labelsPerRow * $labelsPerColumn;
 
@@ -60,15 +31,13 @@ class LabelCombiner implements LabelCombinerInterface
                 : $pageSize
         );
 
-        // If we're not starting at position 0, add a page, because it won't be
-        // added in the loop.
+        // If we're not starting at position 0, add a page, because it won't be added in the loop.
         if (($labelPosition = $this->getStartPosition($pageSize, $startLocation)) > 0) {
             $pdf->AddPage();
         }
 
         foreach ($files as $file) {
-            // Whenever we the max number of labels is on a page, create a
-            // new page.
+            // Whenever we the max number of labels is on a page, create a new page.
             if ($labelPosition % $labelsPerPage === 0) {
                 $pdf->AddPage();
             }
@@ -99,92 +68,62 @@ class LabelCombiner implements LabelCombinerInterface
     }
 
     /**
-     * Get an array with the number of labels per row and column for given page
-     * size.
-     *
-     * @param string $pageSize
-     * @return array
+     * Get an array with the number of labels per row and column for given page size.
      */
-    private function getLabelsPerPage($pageSize)
+    private function getLabelsPerPage(string $pageSize): array
     {
-        switch ($pageSize) {
-            case self::PAGE_SIZE_A4:
-                return [2, 2];
-            case self::PAGE_SIZE_A5:
-                return [1, 2];
-            case self::PAGE_SIZE_A6:
-                return [1, 1];
-            default:
-                throw new LabelCombinerException('unknown page size: ' . $pageSize);
-        }
+        return match ($pageSize) {
+            self::PAGE_SIZE_A4 => [2, 2],
+            self::PAGE_SIZE_A5 => [1, 2],
+            self::PAGE_SIZE_A6 => [1, 1],
+            default => throw new LabelCombinerException('unknown page size: ' . $pageSize),
+        };
     }
 
     /**
      * Get the orientation for given page size.
-     *
-     * @param string $pageSize
-     * @return string
      */
-    private function getOrientation($pageSize)
+    private function getOrientation(string $pageSize): string
     {
-        switch ($pageSize) {
-            case self::PAGE_SIZE_A4:
-            case self::PAGE_SIZE_A6:
-                return 'L';
-            case self::PAGE_SIZE_A5:
-                return 'P';
-            default:
-                throw new LabelCombinerException('unknown page size: ' . $pageSize);
-        }
+        return match ($pageSize) {
+            self::PAGE_SIZE_A4, self::PAGE_SIZE_A6 => 'L',
+            self::PAGE_SIZE_A5 => 'P',
+            default => throw new LabelCombinerException('unknown page size: ' . $pageSize),
+        };
     }
 
     /**
      * Return the start position, 0 being top left and 3 being bottom right.
-     *
-     * @param string $pageSize
-     * @param int    $startLocation
-     * @return int
      */
-    private function getStartPosition($pageSize, $startLocation)
+    private function getStartPosition(string $pageSize, int $startLocation): int
     {
         $top = $startLocation & self::LOCATION_TOP;
         $left = $startLocation & self::LOCATION_LEFT;
 
-        switch ($pageSize) {
-            case self::PAGE_SIZE_A4:
-                return ($top ? 0 : 2) + ($left ? 0 : 1);
-            case self::PAGE_SIZE_A5:
-                return $top ? 0 : 1;
-            case self::PAGE_SIZE_A6:
-                return 0;
-            default:
-                throw new LabelCombinerException('unknown page size: ' . $pageSize);
-        }
+        return match ($pageSize) {
+            self::PAGE_SIZE_A4 => ($top ? 0 : 2) + ($left ? 0 : 1),
+            self::PAGE_SIZE_A5 => $top ? 0 : 1,
+            self::PAGE_SIZE_A6 => 0,
+            default => throw new LabelCombinerException('unknown page size: ' . $pageSize),
+        };
     }
 
     /**
-     * Get an array with the x position, y position and width of the label on
-     * given label position.
-     *
-     * @param int $labelPosition
-     * @param int $labelsPerRow
-     * @param int $labelsPerColumn
-     * @param int $margin
-     * @return array
+     * Get an array with the x position, y position and width of the label on given label position.
      */
-    private function calculateDimensions($labelPosition, $labelsPerRow, $labelsPerColumn, $margin)
-    {
-        // The x position should be the margin, plus the label width for
-        // every label printed on the right side.
+    private function calculateDimensions(
+        int $labelPosition,
+        int $labelsPerRow,
+        int $labelsPerColumn,
+        int $margin,
+    ): array {
+        // The x position should be the margin, plus the label width for every label printed on the right side.
         $x = $margin + ($labelPosition % $labelsPerRow) * self::LABEL_WIDTH;
 
-        // The y position should be the margin scaled to the margin for
-        // x (√2:2), plus the label height if the label is on the
-        // bottom.
+        // The y position should be the margin scaled to the margin for x (√2:2), plus the label height if the label is on the bottom.
         $y = $margin * sqrt(2) / 2 + (floor($labelPosition / $labelsPerRow) % $labelsPerColumn) * self::LABEL_HEIGHT;
 
-        // The width is the label width, minus twice the margin (1 for
-        // each side).
+        // The width is the label width, minus twice the margin (1 for each side).
         $width = self::LABEL_WIDTH - $margin * 2;
 
         return [

--- a/src/LabelCombiner.php
+++ b/src/LabelCombiner.php
@@ -47,7 +47,7 @@ class LabelCombiner implements LabelCombinerInterface
         $startLocation = self::LOCATION_TOP_LEFT,
         $margin = 0
     ) {
-        list($labelsPerRow, $labelsPerColumn) = $this->getLabelsPerPage($pageSize);
+        [$labelsPerRow, $labelsPerColumn] = $this->getLabelsPerPage($pageSize);
         $labelsPerPage = $labelsPerRow * $labelsPerColumn;
 
         $pdf = new Fpdi(
@@ -71,7 +71,7 @@ class LabelCombiner implements LabelCombinerInterface
                 $pdf->AddPage();
             }
 
-            list($x, $y, $width) = $this->calculateDimensions($labelPosition, $labelsPerRow, $labelsPerColumn, $margin);
+            [$x, $y, $width] = $this->calculateDimensions($labelPosition, $labelsPerRow, $labelsPerColumn, $margin);
 
             $formats = $file->getFormats();
             $format = reset($formats);

--- a/src/LabelCombinerInterface.php
+++ b/src/LabelCombinerInterface.php
@@ -44,17 +44,12 @@ interface LabelCombinerInterface
      * PAGE_SIZE_A6
      * - LOCATION_TOP
      *
-     * @param FileInterface[] $files
-     * @param string          $pageSize
-     * @param int             $startLocation
-     * @param int             $margin
-     * @return FileInterface
      * @throws MyParcelComException
      */
     public function combineLabels(
         array $files,
-        $pageSize = self::PAGE_SIZE_A4,
-        $startLocation = self::LOCATION_TOP_LEFT,
-        $margin = 0
-    );
+        string $pageSize = self::PAGE_SIZE_A4,
+        int $startLocation = self::LOCATION_TOP_LEFT,
+        int $margin = 0
+    ): FileInterface;
 }

--- a/src/LabelCombinerInterface.php
+++ b/src/LabelCombinerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk;
 
 use MyParcelCom\ApiSdk\Exceptions\MyParcelComException;

--- a/src/MyParcelComApi.php
+++ b/src/MyParcelComApi.php
@@ -47,7 +47,7 @@ class MyParcelComApi implements MyParcelComApiInterface
     private ClientInterface $client;
     private bool $authRetry = false;
 
-    private static MyParcelComApi $singleton;
+    private static ?MyParcelComApi $singleton = null;
 
     /**
      * Create a singleton instance of this class, which will be available in subsequent calls to `getSingleton()`.
@@ -66,7 +66,7 @@ class MyParcelComApi implements MyParcelComApiInterface
     /**
      * Get the singleton instance created.
      */
-    public static function getSingleton(): self
+    public static function getSingleton(): ?self
     {
         return self::$singleton;
     }
@@ -413,7 +413,7 @@ class MyParcelComApi implements MyParcelComApiInterface
         return $this->getRequestCollection($url->getUrl(), $ttl);
     }
 
-    public function getShipment(string $id, int $ttl = null): ShipmentInterface
+    public function getShipment(string $id, int $ttl = self::TTL_NO_CACHE): ShipmentInterface
     {
         return $this->getResourceById(ResourceInterface::TYPE_SHIPMENT, $id, $ttl);
     }
@@ -852,7 +852,7 @@ class MyParcelComApi implements MyParcelComApiInterface
     /**
      * Converts given array to a filter string for the query params.
      */
-    private function arrayToFilter(array &$filters, array $keys, array|string $value): void
+    private function arrayToFilter(array &$filters, array $keys, mixed $value): void
     {
         if (is_array($value)) {
             foreach ($value as $key => $nextValue) {

--- a/src/MyParcelComApi.php
+++ b/src/MyParcelComApi.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk;
 
 use GuzzleHttp\Psr7\Message;

--- a/src/MyParcelComApiInterface.php
+++ b/src/MyParcelComApiInterface.php
@@ -143,7 +143,7 @@ interface MyParcelComApiInterface
      *
      * @throws MyParcelComException
      */
-    public function getShipment(string $id, int $ttl = null): ShipmentInterface;
+    public function getShipment(string $id, int $ttl = self::TTL_NO_CACHE): ShipmentInterface;
 
     /**
      * Creates a given shipment or updates it depending on if the id is already set.

--- a/src/MyParcelComApiInterface.php
+++ b/src/MyParcelComApiInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk;
 
 use MyParcelCom\ApiSdk\Authentication\AuthenticatorInterface;

--- a/src/MyParcelComApiInterface.php
+++ b/src/MyParcelComApiInterface.php
@@ -35,11 +35,9 @@ interface MyParcelComApiInterface
     /**
      * Authenticate to the API using the given authenticator.
      *
-     * @param AuthenticatorInterface $authenticator
-     * @return $this
      * @throws MyParcelComException
      */
-    public function authenticate(AuthenticatorInterface $authenticator);
+    public function authenticate(AuthenticatorInterface $authenticator): self;
 
     /**
      * Get an array with all the regions. An array of

--- a/src/MyParcelComApiInterface.php
+++ b/src/MyParcelComApiInterface.php
@@ -42,150 +42,108 @@ interface MyParcelComApiInterface
     public function authenticate(AuthenticatorInterface $authenticator): self;
 
     /**
-     * Get an array with all the regions. An array of
-     * filters can be provided to limit the results to
-     * a subset. Available filters:
-     * - country_code
-     * - region_code
-     * - postal_code
-     *
-     * @see https://docs.myparcel.com/api/resources/regions/#parameters
-     *
-     * @param array $filters
-     * @param int   $ttl Cache time to live (in seconds)
-     * @return CollectionInterface
+     * @deprecated
      */
-    public function getRegions($filters = [], $ttl = self::TTL_10MIN);
+    public function getRegions(array $filters = [], int $ttl = self::TTL_10MIN): CollectionInterface;
 
     /**
      * Get all the carriers from the API.
      *
-     * @param int $ttl Cache time to live (in seconds)
-     * @return CollectionInterface
      * @throws MyParcelComException
      */
-    public function getCarriers($ttl = self::TTL_10MIN);
+    public function getCarriers(int $ttl = self::TTL_10MIN): CollectionInterface;
 
     /**
-     * Get the pick up/drop off locations around a given location. If no carrier
-     * is given, pick up locations for all available carriers will be used.
-     *
-     * @param string                $countryCode
-     * @param string                $postalCode
-     * @param string|null           $streetName
-     * @param string|null           $streetNumber
-     * @param CarrierInterface|null $specificCarrier
-     * @param bool                  $onlyActiveContracts
-     * @param int                   $ttl Cache time to live (in seconds)
-     * @return CollectionInterface
+     * Get the pick-up/drop-off locations around a given location.
+     * If no specific carrier is given, an array of pick-up location collections for all available carriers is returned.
      */
     public function getPickUpDropOffLocations(
-        $countryCode,
-        $postalCode,
-        $streetName = null,
-        $streetNumber = null,
+        string $countryCode,
+        string $postalCode,
+        ?string $streetName = null,
+        ?string $streetNumber = null,
         CarrierInterface $specificCarrier = null,
-        $onlyActiveContracts = true,
-        $ttl = self::TTL_10MIN
-    );
+        bool $onlyActiveContracts = true,
+        int $ttl = self::TTL_10MIN,
+    ): CollectionInterface|array;
 
     /**
      * Get the shops from the API.
      *
-     * @param int $ttl Cache time to live (in seconds)
-     * @return CollectionInterface
      * @throws MyParcelComException
      */
-    public function getShops($ttl = self::TTL_10MIN);
+    public function getShops(int $ttl = self::TTL_10MIN): CollectionInterface;
 
     /**
-     * Get the default shop that will be used when interacting with the API and
-     * no specific shop has been set.
+     * Get the default shop that will be used when interacting with the API and no specific shop has been set.
      *
-     * @param int $ttl Cache time to live (in seconds)
-     * @return ShopInterface
      * @throws MyParcelComException
      */
-    public function getDefaultShop($ttl = self::TTL_10MIN);
+    public function getDefaultShop(int $ttl = self::TTL_10MIN): ShopInterface;
 
     /**
      * Get all services that can be used for given shipment. If no shipment is
      * provided, all available services are returned.
      *
-     * @param ShipmentInterface|null $shipment
-     * @param array                  $filters
-     * @param int                    $ttl Cache time to live (in seconds)
-     * @return CollectionInterface
      * @throws MyParcelComException
      */
     public function getServices(
         ShipmentInterface $shipment = null,
         array $filters = ['has_active_contract' => 'true'],
-        $ttl = self::TTL_10MIN
-    );
+        int $ttl = self::TTL_10MIN,
+    ): CollectionInterface;
 
     /**
      * Get all the services that are available for the given carrier.
      *
-     * @param CarrierInterface $carrier
-     * @param int              $ttl Cache time to live (in seconds)
-     * @return CollectionInterface
      * @throws MyParcelComException
      */
-    public function getServicesForCarrier(CarrierInterface $carrier, $ttl = self::TTL_10MIN);
+    public function getServicesForCarrier(CarrierInterface $carrier, int $ttl = self::TTL_10MIN): CollectionInterface;
 
     /**
      * Retrieves service rates based on the set filters. Available filters are: service, contract and weight. Note that
      * this function could return service rates which are dynamic. Their price and availability depends on the shipment
      * data and requires communication with the carrier. This info can be retrieved using resolveDynamicServiceRates().
-     *
-     * @param array $filters
-     * @param int   $ttl Cache time to live (in seconds)
-     * @return CollectionInterface
      */
-    public function getServiceRates(array $filters = ['has_active_contract' => 'true'], $ttl = self::TTL_10MIN);
+    public function getServiceRates(
+        array $filters = ['has_active_contract' => 'true'],
+        int $ttl = self::TTL_10MIN,
+    ): CollectionInterface;
 
     /**
      * Retrieves service rates based on the shipment.
      * The shipment needs to have a recipient/sender_address and a weight set.
-     *
-     * @param ShipmentInterface $shipment
-     * @param int               $ttl Cache time to live (in seconds)
-     * @return CollectionInterface
      */
-    public function getServiceRatesForShipment(ShipmentInterface $shipment, $ttl = self::TTL_10MIN);
+    public function getServiceRatesForShipment(
+        ShipmentInterface $shipment,
+        int $ttl = self::TTL_10MIN,
+    ): CollectionInterface;
 
     /**
      * Retrieve dynamic rates (price / options / availability) from the carrier, based on the provided shipment data.
      * The shipment should have a service, contract, addresses, weight and sometimes dimensions are required as well.
      * If you have a ServiceRate which is_dynamic, you can pass it and its service and contract will be used instead.
      *
-     * @param ShipmentInterface|array   $shipmentData
-     * @param ServiceRateInterface|null $dynamicServiceRate
-     * @return ServiceRateInterface[]
      * @throws RequestException
      */
-    public function resolveDynamicServiceRates($shipmentData, $dynamicServiceRate = null);
+    public function resolveDynamicServiceRates(
+        ShipmentInterface|array $shipmentData,
+        ?ServiceRateInterface $dynamicServiceRate = null
+    ): array;
 
     /**
      * Get shipments for a given shop. If no shop is given the default shop is used.
      *
-     * @param ShopInterface|null $shop
-     * @param int                $ttl Cache time to live (in seconds)
-     * @return CollectionInterface
      * @throws MyParcelComException
      */
-    public function getShipments(ShopInterface $shop = null, $ttl = self::TTL_NO_CACHE);
+    public function getShipments(ShopInterface $shop = null, int $ttl = self::TTL_NO_CACHE): CollectionInterface;
 
     /**
      * Get a specific shipment from the API.
      *
-     * @param string $id
-     * @param int    $ttl
-     * @return ShipmentInterface
      * @throws MyParcelComException
      */
-    public function getShipment($id, $ttl = null);
+    public function getShipment(string $id, int $ttl = null): ShipmentInterface;
 
     /**
      * Creates a given shipment or updates it depending on if the id is already set.
@@ -193,63 +151,52 @@ interface MyParcelComApiInterface
      * When certain properties for a new shipment are not set, defaults should be
      * used. When no default value is available, an exception should be thrown.
      *
-     * @param ShipmentInterface $shipment
-     * @return ShipmentInterface
      * @throws MyParcelComException
      */
-    public function saveShipment(ShipmentInterface $shipment);
+    public function saveShipment(ShipmentInterface $shipment): ShipmentInterface;
 
     /**
      * Update the given shipment and returns the updated version of the shipment.
      *
-     * @param ShipmentInterface $shipment
-     * @return ShipmentInterface
      * @throws MyParcelComException
      */
-    public function updateShipment(ShipmentInterface $shipment);
+    public function updateShipment(ShipmentInterface $shipment): ShipmentInterface;
 
     /**
      * Creates a given shipment and returns the created version of the shipment.
      * When certain properties on the shipment are not set, defaults should be
      * used. When no default value is available, an exception should be thrown.
      *
-     * @param ShipmentInterface $shipment
-     * @param string|null $idempotencyKey Use idempotency feature
-     *                                    (see https://docs.myparcel.com/api/create-a-shipment/idempotency.html)
-     * @return ShipmentInterface
+     * @see https://docs.myparcel.com/api/create-a-shipment.html
+     * @see https://docs.myparcel.com/api/create-a-shipment/idempotency.html
      * @throws MyParcelComException
      */
-    public function createShipment(ShipmentInterface $shipment, $idempotencyKey = null);
+    public function createShipment(ShipmentInterface $shipment, ?string $idempotencyKey = null): ShipmentInterface;
 
     /**
      * Get the resource of given type with given id.
      *
-     * @param string $resourceType
-     * @param string $id
-     * @param int    $ttl
-     * @return ResourceInterface
      * @throws MyParcelComException
      */
-    public function getResourceById($resourceType, $id, $ttl = self::TTL_NO_CACHE);
+    public function getResourceById(string $resourceType, string $id, int $ttl = self::TTL_NO_CACHE): ResourceInterface;
 
     /**
      * Get an array of all the resources from given uri.
      *
-     * @param string $uri
      * @return ResourceInterface[]
      */
-    public function getResourcesFromUri($uri);
+    public function getResourcesFromUri(string $uri): array;
 
     /**
      * Do an async request to given uri on the API.
      *
-     * @param string $uri
-     * @param string $method
-     * @param array  $body
-     * @param array  $headers
-     * @param int    $ttl
-     * @return ResponseInterface
      * @throws RequestException
      */
-    public function doRequest($uri, $method = 'get', array $body = [], array $headers = [], $ttl = self::TTL_NO_CACHE);
+    public function doRequest(
+        string $uri,
+        string $method = 'get',
+        array $body = [],
+        array $headers = [],
+        $ttl = self::TTL_NO_CACHE,
+    ): ResponseInterface;
 }

--- a/src/Resources/Address.php
+++ b/src/Resources/Address.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\AddressInterface;

--- a/src/Resources/Carrier.php
+++ b/src/Resources/Carrier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\CarrierInterface;

--- a/src/Resources/CarrierStatus.php
+++ b/src/Resources/CarrierStatus.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources;
 
 use DateTime;

--- a/src/Resources/Contract.php
+++ b/src/Resources/Contract.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\CarrierInterface;

--- a/src/Resources/Customs.php
+++ b/src/Resources/Customs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\CustomsInterface;

--- a/src/Resources/Error.php
+++ b/src/Resources/Error.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\ErrorInterface;

--- a/src/Resources/File.php
+++ b/src/Resources/File.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources;
 
 use GuzzleHttp\Psr7\Utils;

--- a/src/Resources/Interfaces/AddressInterface.php
+++ b/src/Resources/Interfaces/AddressInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 interface AddressInterface extends \JsonSerializable

--- a/src/Resources/Interfaces/CarrierInterface.php
+++ b/src/Resources/Interfaces/CarrierInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 interface CarrierInterface extends ResourceInterface

--- a/src/Resources/Interfaces/CarrierStatusInterface.php
+++ b/src/Resources/Interfaces/CarrierStatusInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 use DateTime;

--- a/src/Resources/Interfaces/ContractInterface.php
+++ b/src/Resources/Interfaces/ContractInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 interface ContractInterface extends ResourceInterface

--- a/src/Resources/Interfaces/CustomsInterface.php
+++ b/src/Resources/Interfaces/CustomsInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 interface CustomsInterface extends \JsonSerializable

--- a/src/Resources/Interfaces/ErrorInterface.php
+++ b/src/Resources/Interfaces/ErrorInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 use JsonSerializable;

--- a/src/Resources/Interfaces/FileInterface.php
+++ b/src/Resources/Interfaces/FileInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 use Psr\Http\Message\StreamInterface;

--- a/src/Resources/Interfaces/OpeningHourInterface.php
+++ b/src/Resources/Interfaces/OpeningHourInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 use DateTime;

--- a/src/Resources/Interfaces/OrganizationInterface.php
+++ b/src/Resources/Interfaces/OrganizationInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 interface OrganizationInterface extends ResourceInterface

--- a/src/Resources/Interfaces/PhysicalPropertiesInterface.php
+++ b/src/Resources/Interfaces/PhysicalPropertiesInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 interface PhysicalPropertiesInterface extends \JsonSerializable

--- a/src/Resources/Interfaces/PickUpDropOffLocationInterface.php
+++ b/src/Resources/Interfaces/PickUpDropOffLocationInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 use MyParcelCom\ApiSdk\Utils\DistanceUtils;

--- a/src/Resources/Interfaces/PositionInterface.php
+++ b/src/Resources/Interfaces/PositionInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 use JsonSerializable;

--- a/src/Resources/Interfaces/RegionInterface.php
+++ b/src/Resources/Interfaces/RegionInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 interface RegionInterface extends ResourceInterface

--- a/src/Resources/Interfaces/ResourceFactoryInterface.php
+++ b/src/Resources/Interfaces/ResourceFactoryInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 use MyParcelCom\ApiSdk\Exceptions\MyParcelComException;

--- a/src/Resources/Interfaces/ResourceInterface.php
+++ b/src/Resources/Interfaces/ResourceInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 /**

--- a/src/Resources/Interfaces/ResourceProxyInterface.php
+++ b/src/Resources/Interfaces/ResourceProxyInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 use MyParcelCom\ApiSdk\MyParcelComApiInterface;

--- a/src/Resources/Interfaces/ServiceInterface.php
+++ b/src/Resources/Interfaces/ServiceInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 interface ServiceInterface extends ResourceInterface

--- a/src/Resources/Interfaces/ServiceOptionInterface.php
+++ b/src/Resources/Interfaces/ServiceOptionInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 interface ServiceOptionInterface extends ResourceInterface

--- a/src/Resources/Interfaces/ServiceRateInterface.php
+++ b/src/Resources/Interfaces/ServiceRateInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 interface ServiceRateInterface extends ResourceInterface

--- a/src/Resources/Interfaces/ShipmentInterface.php
+++ b/src/Resources/Interfaces/ShipmentInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 use DateTime;

--- a/src/Resources/Interfaces/ShipmentItemInterface.php
+++ b/src/Resources/Interfaces/ShipmentItemInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 interface ShipmentItemInterface extends \JsonSerializable

--- a/src/Resources/Interfaces/ShipmentStatusInterface.php
+++ b/src/Resources/Interfaces/ShipmentStatusInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 use DateTime;

--- a/src/Resources/Interfaces/ShopInterface.php
+++ b/src/Resources/Interfaces/ShopInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 use DateTime;

--- a/src/Resources/Interfaces/StatusInterface.php
+++ b/src/Resources/Interfaces/StatusInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Interfaces;
 
 interface StatusInterface extends ResourceInterface

--- a/src/Resources/OpeningHour.php
+++ b/src/Resources/OpeningHour.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources;
 
 use DateTime;

--- a/src/Resources/Organization.php
+++ b/src/Resources/Organization.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\OrganizationInterface;

--- a/src/Resources/PhysicalProperties.php
+++ b/src/Resources/PhysicalProperties.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources;
 
 use MyParcelCom\ApiSdk\Exceptions\MyParcelComException;

--- a/src/Resources/PickUpDropOffLocation.php
+++ b/src/Resources/PickUpDropOffLocation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\AddressInterface;

--- a/src/Resources/Position.php
+++ b/src/Resources/Position.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\PositionInterface;

--- a/src/Resources/Proxy/CarrierProxy.php
+++ b/src/Resources/Proxy/CarrierProxy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Proxy;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\CarrierInterface;

--- a/src/Resources/Proxy/ContractProxy.php
+++ b/src/Resources/Proxy/ContractProxy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Proxy;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\CarrierInterface;

--- a/src/Resources/Proxy/FileProxy.php
+++ b/src/Resources/Proxy/FileProxy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Proxy;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\FileInterface;

--- a/src/Resources/Proxy/FileStreamProxy.php
+++ b/src/Resources/Proxy/FileStreamProxy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Proxy;
 
 use MyParcelCom\ApiSdk\MyParcelComApiInterface;

--- a/src/Resources/Proxy/OrganizationProxy.php
+++ b/src/Resources/Proxy/OrganizationProxy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Proxy;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\OrganizationInterface;

--- a/src/Resources/Proxy/RegionProxy.php
+++ b/src/Resources/Proxy/RegionProxy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Proxy;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\RegionInterface;

--- a/src/Resources/Proxy/ServiceOptionProxy.php
+++ b/src/Resources/Proxy/ServiceOptionProxy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Proxy;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\ResourceInterface;

--- a/src/Resources/Proxy/ServiceProxy.php
+++ b/src/Resources/Proxy/ServiceProxy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Proxy;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\CarrierInterface;

--- a/src/Resources/Proxy/ShipmentProxy.php
+++ b/src/Resources/Proxy/ShipmentProxy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Proxy;
 
 use DateTime;

--- a/src/Resources/Proxy/ShipmentStatusProxy.php
+++ b/src/Resources/Proxy/ShipmentStatusProxy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Proxy;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\CarrierStatusInterface;

--- a/src/Resources/Proxy/ShopProxy.php
+++ b/src/Resources/Proxy/ShopProxy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Proxy;
 
 use DateTime;

--- a/src/Resources/Proxy/StatusProxy.php
+++ b/src/Resources/Proxy/StatusProxy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Proxy;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\ResourceInterface;

--- a/src/Resources/Region.php
+++ b/src/Resources/Region.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\RegionInterface;

--- a/src/Resources/ResourceFactory.php
+++ b/src/Resources/ResourceFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources;
 
 use MyParcelCom\ApiSdk\Enums\TaxTypeEnum;

--- a/src/Resources/Service.php
+++ b/src/Resources/Service.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\CarrierInterface;

--- a/src/Resources/ServiceOption.php
+++ b/src/Resources/ServiceOption.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\ResourceInterface;

--- a/src/Resources/ServiceRate.php
+++ b/src/Resources/ServiceRate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\ContractInterface;

--- a/src/Resources/Shipment.php
+++ b/src/Resources/Shipment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources;
 
 use DateTime;

--- a/src/Resources/ShipmentItem.php
+++ b/src/Resources/ShipmentItem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources;
 
 use MyParcelCom\ApiSdk\Enums\WeightUnitEnum;

--- a/src/Resources/ShipmentStatus.php
+++ b/src/Resources/ShipmentStatus.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources;
 
 use DateTime;

--- a/src/Resources/Shop.php
+++ b/src/Resources/Shop.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources;
 
 use DateTime;

--- a/src/Resources/Status.php
+++ b/src/Resources/Status.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\ResourceInterface;

--- a/src/Resources/TaxIdentificationNumber.php
+++ b/src/Resources/TaxIdentificationNumber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources;
 
 use MyParcelCom\ApiSdk\Enums\TaxTypeEnum;

--- a/src/Resources/Traits/JsonSerializable.php
+++ b/src/Resources/Traits/JsonSerializable.php
@@ -66,7 +66,7 @@ trait JsonSerializable
     {
         $array = [];
         foreach ($arrayValues as $key => $value) {
-            $key = StringUtils::camelToSnakeCase($key);
+            $key = is_string($key) ? StringUtils::camelToSnakeCase($key) : $key;
             $isObjectOrClass = is_object($value) || (is_string($value) && class_exists($value));
 
             if (is_scalar($value)) {

--- a/src/Resources/Traits/JsonSerializable.php
+++ b/src/Resources/Traits/JsonSerializable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Traits;
 
 use MyParcelCom\ApiSdk\Utils\StringUtils;

--- a/src/Resources/Traits/JsonSerializable.php
+++ b/src/Resources/Traits/JsonSerializable.php
@@ -41,11 +41,7 @@ trait JsonSerializable
         return $json;
     }
 
-    /**
-     * @param mixed $values
-     * @return bool
-     */
-    private function isEmpty($values)
+    private function isEmpty(mixed $values): bool
     {
         if ($values === [] || $values === null) {
             return true;
@@ -64,13 +60,9 @@ trait JsonSerializable
     }
 
     /**
-     * Helper function to recursively convert all values in an array to scalar
-     * values or arrays with scalar values.
-     *
-     * @param array $arrayValues
-     * @return array
+     * Helper function to recursively convert all values in an array to scalar values or arrays with scalar values.
      */
-    private function arrayValuesToArray(array $arrayValues)
+    private function arrayValuesToArray(array $arrayValues): array
     {
         $array = [];
         foreach ($arrayValues as $key => $value) {
@@ -91,11 +83,8 @@ trait JsonSerializable
 
     /**
      * Remove all the attributes from the relationships, so it only has `id` and `type` values.
-     *
-     * @param array $relationships
-     * @return array
      */
-    private function removeRelationshipAttributes(array $relationships)
+    private function removeRelationshipAttributes(array $relationships): array
     {
         foreach ($relationships as $name => &$relationship) {
             if (empty($relationship['data'])) {

--- a/src/Resources/Traits/ProcessIncludes.php
+++ b/src/Resources/Traits/ProcessIncludes.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Traits;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\ResourceInterface;

--- a/src/Resources/Traits/ProcessIncludes.php
+++ b/src/Resources/Traits/ProcessIncludes.php
@@ -14,7 +14,7 @@ trait ProcessIncludes
      *
      * @param ResourceInterface[] $includedResources
      */
-    public function processIncludedResources(array $includedResources)
+    public function processIncludedResources(array $includedResources): void
     {
         foreach ($includedResources as $resource) {
             if (!array_key_exists($resource->getType(), self::INCLUDES)) {

--- a/src/Resources/Traits/ProxiesResource.php
+++ b/src/Resources/Traits/ProxiesResource.php
@@ -10,33 +10,21 @@ use MyParcelCom\ApiSdk\Resources\Interfaces\ResourceInterface;
 
 trait ProxiesResource
 {
-    /** @var ResourceInterface */
-    private $resource;
-
-    /** @var MyParcelComApiInterface */
-    private $api;
-
-    /** @var string */
-    private $uri;
+    private ?ResourceInterface $resource = null;
+    private ?MyParcelComApiInterface $api = null;
+    private ?string $uri = null;
 
     /**
      * Set the api to use when retrieving the resource.
-     *
-     * @param MyParcelComApiInterface $api
-     * @return $this
      */
-    public function setMyParcelComApi(MyParcelComApiInterface $api = null)
+    public function setMyParcelComApi(MyParcelComApiInterface $api = null): self
     {
         $this->api = $api;
 
         return $this;
     }
 
-    /**
-     * @param string $uri
-     * @return $this
-     */
-    public function setResourceUri($uri)
+    public function setResourceUri(string $uri): self
     {
         $this->uri = $uri;
 
@@ -45,17 +33,15 @@ trait ProxiesResource
 
     /**
      * Get the resource that this instance is a proxy for.
-     *
-     * @return ResourceInterface
      */
-    protected function getResource()
+    protected function getResource(): ResourceInterface
     {
         if (isset($this->resource)) {
             return $this->resource;
         }
 
         if (!isset($this->api)) {
-            throw  new MyParcelComException('No API object set on proxy, cannot retrieve resource');
+            throw new MyParcelComException('No API object set on proxy, cannot retrieve resource');
         }
 
         if (isset($this->uri)) {

--- a/src/Resources/Traits/ProxiesResource.php
+++ b/src/Resources/Traits/ProxiesResource.php
@@ -24,7 +24,7 @@ trait ProxiesResource
         return $this;
     }
 
-    public function setResourceUri(string $uri): self
+    public function setResourceUri(?string $uri): self
     {
         $this->uri = $uri;
 
@@ -34,7 +34,7 @@ trait ProxiesResource
     /**
      * Get the resource that this instance is a proxy for.
      */
-    protected function getResource(): ResourceInterface
+    protected function getResource(): ?ResourceInterface
     {
         if (isset($this->resource)) {
             return $this->resource;

--- a/src/Resources/Traits/ProxiesResource.php
+++ b/src/Resources/Traits/ProxiesResource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Resources\Traits;
 
 use MyParcelCom\ApiSdk\Exceptions\MyParcelComException;

--- a/src/Shipments/PriceCalculator.php
+++ b/src/Shipments/PriceCalculator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Shipments;
 
 use MyParcelCom\ApiSdk\Exceptions\CalculationException;

--- a/src/Shipments/PriceCalculator.php
+++ b/src/Shipments/PriceCalculator.php
@@ -14,12 +14,8 @@ class PriceCalculator
 {
     /**
      * Calculate the total price of given shipment based off its contract, service and weight.
-     *
-     * @param ShipmentInterface         $shipment
-     * @param ServiceRateInterface|null $serviceRate
-     * @return null|int
      */
-    public function calculate(ShipmentInterface $shipment, ServiceRateInterface $serviceRate = null)
+    public function calculate(ShipmentInterface $shipment, ?ServiceRateInterface $serviceRate = null): ?int
     {
         if ($serviceRate === null) {
             $serviceRate = $this->determineServiceRateForShipment($shipment);
@@ -63,12 +59,8 @@ class PriceCalculator
 
     /**
      * Calculate the price based on the selected options for given shipment.
-     *
-     * @param ShipmentInterface         $shipment
-     * @param ServiceRateInterface|null $serviceRate
-     * @return null|int
      */
-    public function calculateOptionsPrice(ShipmentInterface $shipment, ServiceRateInterface $serviceRate = null)
+    public function calculateOptionsPrice(ShipmentInterface $shipment, ?ServiceRateInterface $serviceRate = null): ?int
     {
         if ($serviceRate === null) {
             $serviceRate = $this->determineServiceRateForShipment($shipment);
@@ -101,10 +93,9 @@ class PriceCalculator
     }
 
     /**
-     * @param ShipmentInterface $shipment
      * @throws InvalidResourceException
      */
-    private function validateShipment(ShipmentInterface $shipment)
+    private function validateShipment(ShipmentInterface $shipment): void
     {
         if ($shipment->getPhysicalProperties() === null
             || $shipment->getPhysicalProperties()->getWeight() === null
@@ -126,11 +117,7 @@ class PriceCalculator
         }
     }
 
-    /**
-     * @param ShipmentInterface $shipment
-     * @return ServiceRateInterface
-     */
-    private function determineServiceRateForShipment(ShipmentInterface $shipment)
+    private function determineServiceRateForShipment(ShipmentInterface $shipment): ServiceRateInterface
     {
         $this->validateShipment($shipment);
 

--- a/src/Shipments/ServiceMatcher.php
+++ b/src/Shipments/ServiceMatcher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Shipments;
 
 use MyParcelCom\ApiSdk\Exceptions\InvalidResourceException;

--- a/src/Shipments/ServiceMatcher.php
+++ b/src/Shipments/ServiceMatcher.php
@@ -7,19 +7,14 @@ namespace MyParcelCom\ApiSdk\Shipments;
 use MyParcelCom\ApiSdk\Exceptions\InvalidResourceException;
 use MyParcelCom\ApiSdk\Resources\Interfaces\ServiceInterface;
 use MyParcelCom\ApiSdk\Resources\Interfaces\ServiceOptionInterface;
-use MyParcelCom\ApiSdk\Resources\Interfaces\ServiceRateInterface;
 use MyParcelCom\ApiSdk\Resources\Interfaces\ShipmentInterface;
 
 class ServiceMatcher
 {
     /**
      * Returns true if given service can be used for the given shipment.
-     *
-     * @param ShipmentInterface $shipment
-     * @param ServiceInterface  $service
-     * @return bool
      */
-    public function matches(ShipmentInterface $shipment, ServiceInterface $service)
+    public function matches(ShipmentInterface $shipment, ServiceInterface $service): bool
     {
         if (
             $shipment->getPhysicalProperties() === null
@@ -43,12 +38,8 @@ class ServiceMatcher
 
     /**
      * Returns true if the service has a delivery method that matches the shipment.
-     *
-     * @param ShipmentInterface $shipment
-     * @param ServiceInterface  $service
-     * @return bool
      */
-    public function matchesDeliveryMethod(ShipmentInterface $shipment, ServiceInterface $service)
+    public function matchesDeliveryMethod(ShipmentInterface $shipment, ServiceInterface $service): bool
     {
         $deliveryMethod = $shipment->getPickupLocationCode()
             ? ServiceInterface::DELIVERY_METHOD_PICKUP
@@ -59,12 +50,8 @@ class ServiceMatcher
 
     /**
      * Returns a subset of the given service rates that have all the options that the shipment requires.
-     *
-     * @param ShipmentInterface      $shipment
-     * @param ServiceRateInterface[] $serviceRates
-     * @return ServiceRateInterface[]
      */
-    public function getMatchedOptions(ShipmentInterface $shipment, array $serviceRates)
+    public function getMatchedOptions(ShipmentInterface $shipment, array $serviceRates): array
     {
         $optionIds = array_map(function (ServiceOptionInterface $option) {
             return $option->getId();

--- a/src/Traits/HasErrors.php
+++ b/src/Traits/HasErrors.php
@@ -6,36 +6,28 @@ namespace MyParcelCom\ApiSdk\Traits;
 
 trait HasErrors
 {
-    /** @var array */
-    protected $errors = [];
+    protected array $errors = [];
 
     /**
      * Get all the errors.
-     *
-     * @return string[]
      */
-    public function getErrors()
+    public function getErrors(): array
     {
         return $this->errors;
     }
 
     /**
      * Returns true if errors are set.
-     *
-     * @return bool
      */
-    public function hasErrors()
+    public function hasErrors(): bool
     {
         return !empty($this->errors);
     }
 
     /**
      * Set all the found errors.
-     *
-     * @param string[] $errors
-     * @return $this
      */
-    public function setErrors(array $errors)
+    public function setErrors(array $errors): self
     {
         $this->errors = $errors;
 
@@ -44,11 +36,8 @@ trait HasErrors
 
     /**
      * Add an error.
-     *
-     * @param string $error
-     * @return $this
      */
-    public function addError($error)
+    public function addError(string $error): self
     {
         $this->errors[] = $error;
 
@@ -57,10 +46,8 @@ trait HasErrors
 
     /**
      * Clears the errors array.
-     *
-     * @return $this
      */
-    public function clearErrors()
+    public function clearErrors(): self
     {
         $this->errors = [];
 

--- a/src/Traits/HasErrors.php
+++ b/src/Traits/HasErrors.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Traits;
 
 trait HasErrors

--- a/src/Utils/DateUtils.php
+++ b/src/Utils/DateUtils.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Utils;
 
 use DateTime;

--- a/src/Utils/DateUtils.php
+++ b/src/Utils/DateUtils.php
@@ -5,15 +5,10 @@ declare(strict_types=1);
 namespace MyParcelCom\ApiSdk\Utils;
 
 use DateTime;
-use InvalidArgumentException;
 
 class DateUtils
 {
-    /**
-     * @param DateTime|string|int $dateTime
-     * @return int
-     */
-    public static function toTimestamp($dateTime)
+    public static function toTimestamp(DateTime|int|string $dateTime): int
     {
         if (is_int($dateTime)) {
             return $dateTime;
@@ -23,17 +18,6 @@ class DateUtils
             return (new DateTime($dateTime))->getTimestamp();
         }
 
-        if ($dateTime instanceof DateTime) {
-            return $dateTime->getTimestamp();
-        }
-
-        throw new InvalidArgumentException(
-            sprintf(
-                '$dateTime must be an instance of DateTime, string or integer, %s given',
-                gettype($dateTime) === 'object'
-                    ? get_class($dateTime)
-                    : gettype($dateTime)
-            )
-        );
+        return $dateTime->getTimestamp();
     }
 }

--- a/src/Utils/DistanceUtils.php
+++ b/src/Utils/DistanceUtils.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Utils;
 
 use MyParcelCom\ApiSdk\Exceptions\ConversionException;

--- a/src/Utils/DistanceUtils.php
+++ b/src/Utils/DistanceUtils.php
@@ -13,8 +13,7 @@ class DistanceUtils
     const UNIT_MILE = 'miles';
     const UNIT_FOOT = 'feet';
 
-    /** @var array */
-    private static $unitConversion = [
+    private static array $unitConversion = [
         self::UNIT_METER     => 1,
         self::UNIT_KILOMETER => 1000,
         self::UNIT_MILE      => 1609.344,
@@ -26,13 +25,8 @@ class DistanceUtils
      *
      * @example DistanceUtils::convertDistance(100, DistanceUtils::UNIT_KILOMETER, DistanceUtils::UNIT_MILE)
      *          will return `62,137119224`.
-     *
-     * @param float|int $distance
-     * @param string    $sourceUnit
-     * @param string    $destinationUnit
-     * @return float|int
      */
-    public static function convertDistance($distance, $sourceUnit, $destinationUnit)
+    public static function convertDistance(float|int $distance, string $sourceUnit, string $destinationUnit): float|int
     {
         if (!isset(self::$unitConversion[$sourceUnit])) {
             throw new ConversionException('Cannot convert distance with unit: ' . $sourceUnit);

--- a/src/Utils/StringUtils.php
+++ b/src/Utils/StringUtils.php
@@ -8,33 +8,24 @@ class StringUtils
 {
     /**
      * Transforms a string in snake_case to camelCase.
-     *
-     * @param string $snakeCase
-     * @return string
      */
-    public static function snakeToCamelCase($snakeCase)
+    public static function snakeToCamelCase(string $snakeCase): string
     {
         return lcfirst(self::snakeToPascalCase($snakeCase));
     }
 
     /**
      * Transforms a string from snake_case to PascalCase.
-     *
-     * @param string $snakeCase
-     * @return string
      */
-    public static function snakeToPascalCase($snakeCase)
+    public static function snakeToPascalCase(string $snakeCase): string
     {
         return str_replace('_', '', ucwords($snakeCase, '_'));
     }
 
     /**
      * Transforms a string from camelCase to snake_case.
-     *
-     * @param string $camelCase
-     * @return string
      */
-    public static function camelToSnakeCase($camelCase)
+    public static function camelToSnakeCase(string $camelCase): string
     {
         return strtolower(preg_replace('/(?<=\d)(?=[A-Za-z])|(?<=[A-Za-z])(?=\d)|(?<=[a-z])(?=[A-Z])/', '_', $camelCase));
     }

--- a/src/Utils/StringUtils.php
+++ b/src/Utils/StringUtils.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Utils;
 
 class StringUtils

--- a/src/Utils/UrlBuilder.php
+++ b/src/Utils/UrlBuilder.php
@@ -6,37 +6,17 @@ namespace MyParcelCom\ApiSdk\Utils;
 
 class UrlBuilder
 {
-    /** @var string */
-    protected $url;
+    protected ?string $url = null;
+    protected ?string $scheme = null;
+    protected ?string $host = null;
+    protected ?int $port = null;
+    protected ?string $user = null;
+    protected ?string $password = null;
+    protected ?string $path = null;
+    protected ?string $fragment = null;
+    protected array $query = [];
 
-    /** @var string */
-    protected $scheme;
-
-    /** @var string */
-    protected $host;
-
-    /** @var int */
-    protected $port;
-
-    /** @var string */
-    protected $user;
-
-    /** @var string */
-    protected $password;
-
-    /** @var string */
-    protected $path;
-
-    /** @var array */
-    protected $query = [];
-
-    /** @var string */
-    protected $fragment;
-
-    /**
-     * @param string $url
-     */
-    public function __construct($url = null)
+    public function __construct(string $url = null)
     {
         if ($url !== null) {
             $this->setUrl($url);
@@ -45,22 +25,19 @@ class UrlBuilder
 
     /**
      * Set the base url.
-     *
-     * @param string $url
-     * @return $this
      */
-    public function setUrl($url)
+    public function setUrl(string $url): self
     {
         $this->url = $url;
         $parts = parse_url($url);
 
-        $this->scheme = isset($parts['scheme']) ? $parts['scheme'] : null;
-        $this->host = isset($parts['host']) ? $parts['host'] : null;
-        $this->port = isset($parts['port']) ? $parts['port'] : null;
-        $this->user = isset($parts['user']) ? $parts['user'] : null;
-        $this->password = isset($parts['pass']) ? $parts['pass'] : null;
-        $this->path = isset($parts['path']) ? $parts['path'] : null;
-        $this->fragment = isset($parts['fragment']) ? $parts['fragment'] : null;
+        $this->scheme = $parts['scheme'] ?? null;
+        $this->host = $parts['host'] ?? null;
+        $this->port = $parts['port'] ?? null;
+        $this->user = $parts['user'] ?? null;
+        $this->password = $parts['pass'] ?? null;
+        $this->path = $parts['path'] ?? null;
+        $this->fragment = $parts['fragment'] ?? null;
 
         if (isset($parts['query'])) {
             parse_str($parts['query'], $this->query);
@@ -71,10 +48,8 @@ class UrlBuilder
 
     /**
      * Get the compiled url.
-     *
-     * @return string
      */
-    public function getUrl()
+    public function getUrl(): string
     {
         $url = '';
         if ($this->scheme) {
@@ -108,21 +83,16 @@ class UrlBuilder
 
     /**
      * Get the GET query params.
-     *
-     * @return array
      */
-    public function getQuery()
+    public function getQuery(): array
     {
         return $this->query;
     }
 
     /**
      * Set the GET query params.
-     *
-     * @param array $query
-     * @return $this
      */
-    public function setQuery(array $query)
+    public function setQuery(array $query): self
     {
         $this->query = $query;
 
@@ -131,11 +101,8 @@ class UrlBuilder
 
     /**
      * Add GET query params.
-     *
-     * @param array $query
-     * @return $this
      */
-    public function addQuery(array $query)
+    public function addQuery(array $query): self
     {
         $this->query = array_merge($this->query, $query);
 
@@ -144,21 +111,16 @@ class UrlBuilder
 
     /**
      * Get the scheme of the url.
-     *
-     * @return string|null
      */
-    public function getScheme()
+    public function getScheme(): ?string
     {
         return $this->scheme;
     }
 
     /**
      * Set the scheme of the url.
-     *
-     * @param string $scheme
-     * @return $this
      */
-    public function setScheme($scheme)
+    public function setScheme(string $scheme): self
     {
         $this->scheme = $scheme;
 
@@ -167,21 +129,16 @@ class UrlBuilder
 
     /**
      * Get the host of the url.
-     *
-     * @return string|null
      */
-    public function getHost()
+    public function getHost(): ?string
     {
         return $this->host;
     }
 
     /**
      * Set the host of the url.
-     *
-     * @param string $host
-     * @return $this
      */
-    public function setHost($host)
+    public function setHost(string $host): self
     {
         $this->host = $host;
 
@@ -190,21 +147,16 @@ class UrlBuilder
 
     /**
      * Get the url port.
-     *
-     * @return int|null
      */
-    public function getPort()
+    public function getPort(): ?int
     {
         return $this->port;
     }
 
     /**
-     * Set the url port
-     *
-     * @param int $port
-     * @return $this
+     * Set the url port.
      */
-    public function setPort($port)
+    public function setPort(int $port): self
     {
         $this->port = $port;
 
@@ -213,21 +165,16 @@ class UrlBuilder
 
     /**
      * Get the HTTP auth user.
-     *
-     * @return string|null
      */
-    public function getUser()
+    public function getUser(): ?string
     {
         return $this->user;
     }
 
     /**
      * Set the HTTP auth user.
-     *
-     * @param string $user
-     * @return $this
      */
-    public function setUser($user)
+    public function setUser(string $user): self
     {
         $this->user = $user;
 
@@ -236,21 +183,16 @@ class UrlBuilder
 
     /**
      * Get the HTTP auth password.
-     *
-     * @return string|null
      */
-    public function getPassword()
+    public function getPassword(): ?string
     {
         return $this->password;
     }
 
     /**
      * Set the HTTP auth password.
-     *
-     * @param string $password
-     * @return $this
      */
-    public function setPassword($password)
+    public function setPassword(string $password): self
     {
         $this->password = $password;
 
@@ -259,21 +201,16 @@ class UrlBuilder
 
     /**
      * Get the path in the url.
-     *
-     * @return string|null
      */
-    public function getPath()
+    public function getPath(): ?string
     {
         return $this->path;
     }
 
     /**
      * Set the url path.
-     *
-     * @param string $path
-     * @return $this
      */
-    public function setPath($path)
+    public function setPath(string $path): self
     {
         $this->path = $path;
 
@@ -282,21 +219,16 @@ class UrlBuilder
 
     /**
      * Get the string after `#` in the url.
-     *
-     * @return string|null
      */
-    public function getFragment()
+    public function getFragment(): ?string
     {
         return $this->fragment;
     }
 
     /**
      * Set the string after `#` in the url.
-     *
-     * @param string $fragment
-     * @return $this
      */
-    public function setFragment($fragment)
+    public function setFragment(string $fragment): self
     {
         $this->fragment = $fragment;
 
@@ -305,10 +237,8 @@ class UrlBuilder
 
     /**
      * Get the compiled url string.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getUrl();
     }

--- a/src/Utils/UrlBuilder.php
+++ b/src/Utils/UrlBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Utils;
 
 class UrlBuilder

--- a/src/Validators/ShipmentValidator.php
+++ b/src/Validators/ShipmentValidator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Validators;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\ShipmentInterface;

--- a/src/Validators/ShipmentValidator.php
+++ b/src/Validators/ShipmentValidator.php
@@ -12,35 +12,24 @@ class ShipmentValidator implements ValidatorInterface
 {
     use HasErrors;
 
-    /** @var ShipmentInterface */
-    protected $shipment;
-
-    public function __construct(ShipmentInterface $shipment)
-    {
-        $this->shipment = $shipment;
+    public function __construct(
+        protected ShipmentInterface $shipment,
+    ) {
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isValid()
+    public function isValid(): bool
     {
         $this->clearErrors();
-
         $this->checkRequired();
-
         $this->checkWeight();
 
         return !$this->hasErrors();
     }
 
     /**
-     * Check if the required properties are set. Add any errors to the errors
-     * array.
-     *
-     * @return void
+     * Check if the required properties are set. Add any errors to the errors array.
      */
-    protected function checkRequired()
+    protected function checkRequired(): void
     {
         $required = ['weight', 'recipient_address', 'sender_address', 'shop'];
 
@@ -55,10 +44,8 @@ class ShipmentValidator implements ValidatorInterface
 
     /**
      * Check whether the weight property is not an invalid value.
-     *
-     * @return void
      */
-    protected function checkWeight()
+    protected function checkWeight(): void
     {
         if ($this->shipment->getWeight() < 0) {
             $this->addError('Negative weight is not allowed');

--- a/src/Validators/ValidatorInterface.php
+++ b/src/Validators/ValidatorInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Validators;
 
 interface ValidatorInterface

--- a/src/Validators/ValidatorInterface.php
+++ b/src/Validators/ValidatorInterface.php
@@ -7,17 +7,12 @@ namespace MyParcelCom\ApiSdk\Validators;
 interface ValidatorInterface
 {
     /**
-     * Returns `true` when the validator deems whatever its validating to be
-     * valid.
-     *
-     * @return bool
+     * Returns `true` when the validator deems whatever its validating to be valid.
      */
-    public function isValid();
+    public function isValid(): bool;
 
     /**
      * Returns an array with all the errors found when validating.
-     *
-     * @return array
      */
-    public function getErrors();
+    public function getErrors(): array;
 }

--- a/tests/Feature/MyParcelComApiTest.php
+++ b/tests/Feature/MyParcelComApiTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MyParcelCom\ApiSdk\Tests\Feature;
 
-use Http\Client\HttpClient;
 use MyParcelCom\ApiSdk\Authentication\AuthenticatorInterface;
 use MyParcelCom\ApiSdk\Collection\CollectionInterface;
 use MyParcelCom\ApiSdk\Exceptions\InvalidResourceException;
@@ -31,6 +30,7 @@ use MyParcelCom\ApiSdk\Resources\Shop;
 use MyParcelCom\ApiSdk\Tests\Traits\MocksApiCommunication;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 
 class MyParcelComApiTest extends TestCase
@@ -41,7 +41,7 @@ class MyParcelComApiTest extends TestCase
     private $authenticator;
     /** @var MyParcelComApi */
     private $api;
-    /** @var HttpClient|PHPUnit_Framework_MockObject_MockObject */
+    /** @var ClientInterface|PHPUnit_Framework_MockObject_MockObject */
     private $client;
 
     protected function setUp(): void

--- a/tests/Feature/MyParcelComApiTest.php
+++ b/tests/Feature/MyParcelComApiTest.php
@@ -676,7 +676,10 @@ class MyParcelComApiTest extends TestCase
             $this->assertLessThanOrEqual(500, $serviceRate->getWeightMin());
             $this->assertEquals('Letter Test', $serviceRate->getService()->getName(), 'Included service name');
             $this->assertEquals('letter-test', $serviceRate->getService()->getCode(), 'Included service code');
-            $this->assertTrue(in_array($serviceRate->getContract()->getName(), ['Contract X', 'Contract Y']), 'Included contract name');
+            $this->assertTrue(in_array($serviceRate->getContract()->getName(), [
+                'Contract X',
+                'Contract Y',
+            ]), 'Included contract name');
         }
     }
 

--- a/tests/Feature/MyParcelComApiTest.php
+++ b/tests/Feature/MyParcelComApiTest.php
@@ -510,48 +510,12 @@ class MyParcelComApiTest extends TestCase
     }
 
     /** @test */
-    public function testGetGbRegionsWithBackwardCompatibility()
-    {
-        $regions = $this->api->getRegions('GB');
-
-        $this->assertInstanceOf(CollectionInterface::class, $regions);
-        $this->assertEquals(9, $regions->count());
-        foreach ($regions as $region) {
-            $this->assertInstanceOf(RegionInterface::class, $region);
-            $this->assertEquals('GB', $region->getCountryCode());
-        }
-
-        $ireland = $this->api->getRegions('GB', 'NIR');
-
-        $this->assertInstanceOf(CollectionInterface::class, $ireland);
-        $this->assertEquals(1, $ireland->count());
-        foreach ($ireland as $region) {
-            $this->assertInstanceOf(RegionInterface::class, $region);
-            $this->assertEquals('GB', $region->getCountryCode());
-            $this->assertEquals('NIR', $region->getRegionCode());
-        }
-    }
-
-    /** @test */
     public function testGetRegionsWithNonExistingRegionCode()
     {
         $regions = $this->api->getRegions([
             'country_code' => 'NL',
             'region_code'  => 'NH',
         ]);
-
-        $this->assertInstanceOf(CollectionInterface::class, $regions);
-        $this->assertEquals(1, $regions->count());
-        foreach ($regions as $region) {
-            $this->assertInstanceOf(RegionInterface::class, $region);
-            $this->assertEquals('NL', $region->getCountryCode());
-        }
-    }
-
-    /** @test */
-    public function testGetRegionsWithNonExistingRegionCodeWithBackwardCompatibility()
-    {
-        $regions = $this->api->getRegions('NL', 'NH');
 
         $this->assertInstanceOf(CollectionInterface::class, $regions);
         $this->assertEquals(1, $regions->count());

--- a/tests/Feature/MyParcelComApiTest.php
+++ b/tests/Feature/MyParcelComApiTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Feature;
 
 use Http\Client\HttpClient;

--- a/tests/Feature/Proxy/CarrierProxyTest.php
+++ b/tests/Feature/Proxy/CarrierProxyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MyParcelCom\ApiSdk\Tests\Feature\Proxy;
 
-use Http\Client\HttpClient;
 use MyParcelCom\ApiSdk\Authentication\AuthenticatorInterface;
 use MyParcelCom\ApiSdk\MyParcelComApi;
 use MyParcelCom\ApiSdk\MyParcelComApiInterface;
@@ -12,12 +11,13 @@ use MyParcelCom\ApiSdk\Resources\Interfaces\ResourceInterface;
 use MyParcelCom\ApiSdk\Resources\Proxy\CarrierProxy;
 use MyParcelCom\ApiSdk\Tests\Traits\MocksApiCommunication;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
 
 class CarrierProxyTest extends TestCase
 {
     use MocksApiCommunication;
 
-    /** @var HttpClient */
+    /** @var ClientInterface */
     private $client;
     /** @var AuthenticatorInterface */
     private $authenticator;

--- a/tests/Feature/Proxy/CarrierProxyTest.php
+++ b/tests/Feature/Proxy/CarrierProxyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Feature\Proxy;
 
 use Http\Client\HttpClient;

--- a/tests/Feature/Proxy/ContractProxyTest.php
+++ b/tests/Feature/Proxy/ContractProxyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MyParcelCom\ApiSdk\Tests\Feature\Proxy;
 
-use Http\Client\HttpClient;
 use MyParcelCom\ApiSdk\Authentication\AuthenticatorInterface;
 use MyParcelCom\ApiSdk\MyParcelComApi;
 use MyParcelCom\ApiSdk\MyParcelComApiInterface;
@@ -13,12 +12,13 @@ use MyParcelCom\ApiSdk\Resources\Interfaces\ResourceInterface;
 use MyParcelCom\ApiSdk\Resources\Proxy\ContractProxy;
 use MyParcelCom\ApiSdk\Tests\Traits\MocksApiCommunication;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
 
 class ContractProxyTest extends TestCase
 {
     use MocksApiCommunication;
 
-    /** @var HttpClient */
+    /** @var ClientInterface */
     private $client;
     /** @var AuthenticatorInterface */
     private $authenticator;

--- a/tests/Feature/Proxy/ContractProxyTest.php
+++ b/tests/Feature/Proxy/ContractProxyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Feature\Proxy;
 
 use Http\Client\HttpClient;

--- a/tests/Feature/Proxy/FileProxyTest.php
+++ b/tests/Feature/Proxy/FileProxyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Feature\Proxy;
 
 use Http\Client\HttpClient;

--- a/tests/Feature/Proxy/FileProxyTest.php
+++ b/tests/Feature/Proxy/FileProxyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MyParcelCom\ApiSdk\Tests\Feature\Proxy;
 
-use Http\Client\HttpClient;
 use MyParcelCom\ApiSdk\Authentication\AuthenticatorInterface;
 use MyParcelCom\ApiSdk\MyParcelComApi;
 use MyParcelCom\ApiSdk\MyParcelComApiInterface;
@@ -12,13 +11,14 @@ use MyParcelCom\ApiSdk\Resources\Interfaces\ResourceInterface;
 use MyParcelCom\ApiSdk\Resources\Proxy\FileProxy;
 use MyParcelCom\ApiSdk\Tests\Traits\MocksApiCommunication;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\StreamInterface;
 
 class FileProxyTest extends TestCase
 {
     use MocksApiCommunication;
 
-    /** @var HttpClient */
+    /** @var ClientInterface */
     private $client;
     /** @var AuthenticatorInterface */
     private $authenticator;

--- a/tests/Feature/Proxy/FileStreamProxyTest.php
+++ b/tests/Feature/Proxy/FileStreamProxyTest.php
@@ -4,20 +4,20 @@ declare(strict_types=1);
 
 namespace MyParcelCom\ApiSdk\Tests\Feature\Proxy;
 
-use Http\Client\HttpClient;
 use MyParcelCom\ApiSdk\Authentication\AuthenticatorInterface;
 use MyParcelCom\ApiSdk\MyParcelComApi;
 use MyParcelCom\ApiSdk\MyParcelComApiInterface;
 use MyParcelCom\ApiSdk\Resources\Proxy\FileStreamProxy;
 use MyParcelCom\ApiSdk\Tests\Traits\MocksApiCommunication;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
 use RuntimeException;
 
 class FileStreamProxyTest extends TestCase
 {
     use MocksApiCommunication;
 
-    /** @var HttpClient */
+    /** @var ClientInterface */
     private $client;
     /** @var AuthenticatorInterface */
     private $authenticator;

--- a/tests/Feature/Proxy/FileStreamProxyTest.php
+++ b/tests/Feature/Proxy/FileStreamProxyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Feature\Proxy;
 
 use Http\Client\HttpClient;

--- a/tests/Feature/Proxy/RegionProxyTest.php
+++ b/tests/Feature/Proxy/RegionProxyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Feature\Proxy;
 
 use Http\Client\HttpClient;

--- a/tests/Feature/Proxy/RegionProxyTest.php
+++ b/tests/Feature/Proxy/RegionProxyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MyParcelCom\ApiSdk\Tests\Feature\Proxy;
 
-use Http\Client\HttpClient;
 use MyParcelCom\ApiSdk\Authentication\AuthenticatorInterface;
 use MyParcelCom\ApiSdk\MyParcelComApi;
 use MyParcelCom\ApiSdk\MyParcelComApiInterface;
@@ -13,12 +12,13 @@ use MyParcelCom\ApiSdk\Resources\Interfaces\ResourceInterface;
 use MyParcelCom\ApiSdk\Resources\Proxy\RegionProxy;
 use MyParcelCom\ApiSdk\Tests\Traits\MocksApiCommunication;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
 
 class RegionProxyTest extends TestCase
 {
     use MocksApiCommunication;
 
-    /** @var HttpClient */
+    /** @var ClientInterface */
     private $client;
 
     /** @var AuthenticatorInterface */

--- a/tests/Feature/Proxy/ServiceOptionProxyTest.php
+++ b/tests/Feature/Proxy/ServiceOptionProxyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MyParcelCom\ApiSdk\Tests\Feature\Proxy;
 
-use Http\Client\HttpClient;
 use MyParcelCom\ApiSdk\Authentication\AuthenticatorInterface;
 use MyParcelCom\ApiSdk\MyParcelComApi;
 use MyParcelCom\ApiSdk\MyParcelComApiInterface;
@@ -12,12 +11,13 @@ use MyParcelCom\ApiSdk\Resources\Interfaces\ResourceInterface;
 use MyParcelCom\ApiSdk\Resources\Proxy\ServiceOptionProxy;
 use MyParcelCom\ApiSdk\Tests\Traits\MocksApiCommunication;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
 
 class ServiceOptionProxyTest extends TestCase
 {
     use MocksApiCommunication;
 
-    /** @var HttpClient */
+    /** @var ClientInterface */
     private $client;
     /** @var AuthenticatorInterface */
     private $authenticator;

--- a/tests/Feature/Proxy/ServiceOptionProxyTest.php
+++ b/tests/Feature/Proxy/ServiceOptionProxyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Feature\Proxy;
 
 use Http\Client\HttpClient;

--- a/tests/Feature/Proxy/ServiceProxyTest.php
+++ b/tests/Feature/Proxy/ServiceProxyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MyParcelCom\ApiSdk\Tests\Feature\Proxy;
 
-use Http\Client\HttpClient;
 use MyParcelCom\ApiSdk\Authentication\AuthenticatorInterface;
 use MyParcelCom\ApiSdk\MyParcelComApi;
 use MyParcelCom\ApiSdk\MyParcelComApiInterface;
@@ -15,12 +14,13 @@ use MyParcelCom\ApiSdk\Resources\Interfaces\ServiceRateInterface;
 use MyParcelCom\ApiSdk\Resources\Proxy\ServiceProxy;
 use MyParcelCom\ApiSdk\Tests\Traits\MocksApiCommunication;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
 
 class ServiceProxyTest extends TestCase
 {
     use MocksApiCommunication;
 
-    /** @var HttpClient */
+    /** @var ClientInterface */
     private $client;
     /** @var AuthenticatorInterface */
     private $authenticator;

--- a/tests/Feature/Proxy/ServiceProxyTest.php
+++ b/tests/Feature/Proxy/ServiceProxyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Feature\Proxy;
 
 use Http\Client\HttpClient;

--- a/tests/Feature/Proxy/ShipmentProxyTest.php
+++ b/tests/Feature/Proxy/ShipmentProxyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MyParcelCom\ApiSdk\Tests\Feature\Proxy;
 
-use Http\Client\HttpClient;
 use MyParcelCom\ApiSdk\Authentication\AuthenticatorInterface;
 use MyParcelCom\ApiSdk\Enums\TaxTypeEnum;
 use MyParcelCom\ApiSdk\MyParcelComApi;
@@ -24,12 +23,13 @@ use MyParcelCom\ApiSdk\Resources\Proxy\ShipmentProxy;
 use MyParcelCom\ApiSdk\Resources\TaxIdentificationNumber;
 use MyParcelCom\ApiSdk\Tests\Traits\MocksApiCommunication;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
 
 class ShipmentProxyTest extends TestCase
 {
     use MocksApiCommunication;
 
-    /** @var HttpClient */
+    /** @var ClientInterface */
     private $client;
     /** @var AuthenticatorInterface */
     private $authenticator;

--- a/tests/Feature/Proxy/ShipmentProxyTest.php
+++ b/tests/Feature/Proxy/ShipmentProxyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Feature\Proxy;
 
 use Http\Client\HttpClient;

--- a/tests/Feature/Proxy/ShipmentProxyTest.php
+++ b/tests/Feature/Proxy/ShipmentProxyTest.php
@@ -431,9 +431,6 @@ class ShipmentProxyTest extends TestCase
             $now,
             $this->shipmentProxy->setRegisterAt((new \DateTime())->setTimestamp($now))->getRegisterAt()->getTimestamp()
         );
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->shipmentProxy->setRegisterAt(new \stdClass());
     }
 
     /** @test */

--- a/tests/Feature/Proxy/ShipmentStatusProxyTest.php
+++ b/tests/Feature/Proxy/ShipmentStatusProxyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Feature\Proxy;
 
 use Http\Client\HttpClient;

--- a/tests/Feature/Proxy/ShipmentStatusProxyTest.php
+++ b/tests/Feature/Proxy/ShipmentStatusProxyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MyParcelCom\ApiSdk\Tests\Feature\Proxy;
 
-use Http\Client\HttpClient;
 use MyParcelCom\ApiSdk\Authentication\AuthenticatorInterface;
 use MyParcelCom\ApiSdk\MyParcelComApi;
 use MyParcelCom\ApiSdk\MyParcelComApiInterface;
@@ -16,12 +15,13 @@ use MyParcelCom\ApiSdk\Resources\Proxy\ShipmentProxy;
 use MyParcelCom\ApiSdk\Resources\Proxy\ShipmentStatusProxy;
 use MyParcelCom\ApiSdk\Tests\Traits\MocksApiCommunication;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
 
 class ShipmentStatusProxyTest extends TestCase
 {
     use MocksApiCommunication;
 
-    /** @var HttpClient */
+    /** @var ClientInterface */
     private $client;
     /** @var AuthenticatorInterface */
     private $authenticator;

--- a/tests/Feature/Proxy/ShopProxyTest.php
+++ b/tests/Feature/Proxy/ShopProxyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Feature\Proxy;
 
 use DateTime;

--- a/tests/Feature/Proxy/ShopProxyTest.php
+++ b/tests/Feature/Proxy/ShopProxyTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace MyParcelCom\ApiSdk\Tests\Feature\Proxy;
 
 use DateTime;
-use Http\Client\HttpClient;
 use MyParcelCom\ApiSdk\Authentication\AuthenticatorInterface;
 use MyParcelCom\ApiSdk\MyParcelComApi;
 use MyParcelCom\ApiSdk\MyParcelComApiInterface;
@@ -14,12 +13,13 @@ use MyParcelCom\ApiSdk\Resources\Interfaces\ResourceInterface;
 use MyParcelCom\ApiSdk\Resources\Proxy\ShopProxy;
 use MyParcelCom\ApiSdk\Tests\Traits\MocksApiCommunication;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
 
 class ShopProxyTest extends TestCase
 {
     use MocksApiCommunication;
 
-    /** @var HttpClient */
+    /** @var ClientInterface */
     private $client;
     /** @var AuthenticatorInterface */
     private $authenticator;

--- a/tests/Feature/Proxy/StatusProxyTest.php
+++ b/tests/Feature/Proxy/StatusProxyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MyParcelCom\ApiSdk\Tests\Feature\Proxy;
 
-use Http\Client\HttpClient;
 use MyParcelCom\ApiSdk\Authentication\AuthenticatorInterface;
 use MyParcelCom\ApiSdk\MyParcelComApi;
 use MyParcelCom\ApiSdk\MyParcelComApiInterface;
@@ -12,12 +11,13 @@ use MyParcelCom\ApiSdk\Resources\Interfaces\ResourceInterface;
 use MyParcelCom\ApiSdk\Resources\Proxy\StatusProxy;
 use MyParcelCom\ApiSdk\Tests\Traits\MocksApiCommunication;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
 
 class StatusProxyTest extends TestCase
 {
     use MocksApiCommunication;
 
-    /** @var HttpClient */
+    /** @var ClientInterface */
     private $client;
     /** @var AuthenticatorInterface */
     private $authenticator;

--- a/tests/Feature/Proxy/StatusProxyTest.php
+++ b/tests/Feature/Proxy/StatusProxyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Feature\Proxy;
 
 use Http\Client\HttpClient;

--- a/tests/Feature/ResourceFactoryTest.php
+++ b/tests/Feature/ResourceFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Feature;
 
 use MyParcelCom\ApiSdk\MyParcelComApi;

--- a/tests/Traits/MocksApiCommunication.php
+++ b/tests/Traits/MocksApiCommunication.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Traits;
 
 use GuzzleHttp\Psr7\Request;

--- a/tests/Traits/MocksContract.php
+++ b/tests/Traits/MocksContract.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Traits;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\ContractInterface;

--- a/tests/Unit/AddressTest.php
+++ b/tests/Unit/AddressTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Resources\Address;

--- a/tests/Unit/ArrayCollectionTest.php
+++ b/tests/Unit/ArrayCollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Collection\ArrayCollection;

--- a/tests/Unit/Authentication/ClientCredentialsTest.php
+++ b/tests/Unit/Authentication/ClientCredentialsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit\Authentication;
 
 use GuzzleHttp\Psr7\Message;

--- a/tests/Unit/Authentication/ClientCredentialsTest.php
+++ b/tests/Unit/Authentication/ClientCredentialsTest.php
@@ -6,17 +6,17 @@ namespace MyParcelCom\ApiSdk\Tests\Unit\Authentication;
 
 use GuzzleHttp\Psr7\Message;
 use GuzzleHttp\Psr7\Request;
-use Http\Client\HttpClient;
 use MyParcelCom\ApiSdk\Authentication\ClientCredentials;
 use MyParcelCom\ApiSdk\Exceptions\AuthenticationException;
 use MyParcelCom\ApiSdk\Http\Exceptions\RequestException;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 class ClientCredentialsTest extends TestCase
 {
-    /** @var HttpClient */
+    /** @var ClientInterface */
     private $httpClient;
 
     /** @var int */
@@ -51,7 +51,7 @@ class ClientCredentialsTest extends TestCase
             ->willReturn(200);
 
         // Mock an http client.
-        $this->httpClient = $this->getMockBuilder(HttpClient::class)
+        $this->httpClient = $this->getMockBuilder(ClientInterface::class)
             ->disableOriginalConstructor()
             ->disableOriginalClone()
             ->disableArgumentCloning()
@@ -62,7 +62,7 @@ class ClientCredentialsTest extends TestCase
             ->willReturnCallback(function (RequestInterface $request) {
                 $method = strtolower($request->getMethod());
                 $path = urldecode((string) $request->getUri());
-                $jsonBody = json_decode($request->getBody()->getContents(), true);
+                $jsonBody = json_decode((string) $request->getBody(), true);
 
                 if ($this->response->getStatusCode() >= 400) {
                     throw new RequestException(new Request($method, $path), $this->response);

--- a/tests/Unit/Authentication/ClientCredentialsTest.php
+++ b/tests/Unit/Authentication/ClientCredentialsTest.php
@@ -190,14 +190,14 @@ content-type: application/vnd.api+json
      */
     public function testGetAuthorizationHeaderConcurrentRequests()
     {
-        list($processA, $outputA) = $this->runEchoAuthHeader();
+        [$processA, $outputA] = $this->runEchoAuthHeader();
         // After firing the first process, we need to wait for a bit to make
         // sure it is actually running.
         // Note that the fact that we have to wait here implies that 2 auth
         // attempts at exactly the same time will still cause 2 requests to the
         // server.
         usleep(10000);
-        list($processB, $outputB) = $this->runEchoAuthHeader();
+        [$processB, $outputB] = $this->runEchoAuthHeader();
 
         // Wait for the contents (which should be the headers exported).
         $headerA = stream_get_contents($outputA);

--- a/tests/Unit/CarrierStatusTest.php
+++ b/tests/Unit/CarrierStatusTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Resources\CarrierStatus;

--- a/tests/Unit/CarrierTest.php
+++ b/tests/Unit/CarrierTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Resources\Carrier;

--- a/tests/Unit/ContractTest.php
+++ b/tests/Unit/ContractTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Resources\Contract;

--- a/tests/Unit/CustomsTest.php
+++ b/tests/Unit/CustomsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Resources\Customs;

--- a/tests/Unit/ErrorTest.php
+++ b/tests/Unit/ErrorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Resources\Error;

--- a/tests/Unit/FileTest.php
+++ b/tests/Unit/FileTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Resources\File;

--- a/tests/Unit/LabelCombinerTest.php
+++ b/tests/Unit/LabelCombinerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Exceptions\LabelCombinerException;

--- a/tests/Unit/LabelCombinerTest.php
+++ b/tests/Unit/LabelCombinerTest.php
@@ -200,6 +200,6 @@ class LabelCombinerTest extends TestCase
         $combiner = new LabelCombiner();
 
         $this->expectException(LabelCombinerException::class);
-        $combiner->combineLabels([], null);
+        $combiner->combineLabels([], 'nope');
     }
 }

--- a/tests/Unit/OpeningHourTest.php
+++ b/tests/Unit/OpeningHourTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Resources\OpeningHour;

--- a/tests/Unit/PhysicalPropertiesTest.php
+++ b/tests/Unit/PhysicalPropertiesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\PhysicalPropertiesInterface;

--- a/tests/Unit/PickUpDropOffLocationTest.php
+++ b/tests/Unit/PickUpDropOffLocationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Exceptions\MyParcelComException;

--- a/tests/Unit/PositionTest.php
+++ b/tests/Unit/PositionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Resources\Position;

--- a/tests/Unit/PriceCalculatorTest.php
+++ b/tests/Unit/PriceCalculatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Exceptions\CalculationException;

--- a/tests/Unit/PromiseCollectionTest.php
+++ b/tests/Unit/PromiseCollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Collection\CollectionInterface;

--- a/tests/Unit/RegionTest.php
+++ b/tests/Unit/RegionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\RegionInterface;

--- a/tests/Unit/ServiceMatcherTest.php
+++ b/tests/Unit/ServiceMatcherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Exceptions\InvalidResourceException;

--- a/tests/Unit/ServiceOptionTest.php
+++ b/tests/Unit/ServiceOptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Resources\ServiceOption;

--- a/tests/Unit/ServiceRateTest.php
+++ b/tests/Unit/ServiceRateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Resources\Contract;

--- a/tests/Unit/ServiceTest.php
+++ b/tests/Unit/ServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\CarrierInterface;

--- a/tests/Unit/ShipmentItemTest.php
+++ b/tests/Unit/ShipmentItemTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Enums\WeightUnitEnum;

--- a/tests/Unit/ShipmentStatusTest.php
+++ b/tests/Unit/ShipmentStatusTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\CarrierStatusInterface;

--- a/tests/Unit/ShipmentTest.php
+++ b/tests/Unit/ShipmentTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Enums\TaxTypeEnum;

--- a/tests/Unit/ShipmentTest.php
+++ b/tests/Unit/ShipmentTest.php
@@ -431,9 +431,6 @@ class ShipmentTest extends TestCase
             $now,
             $shipment->setRegisterAt((new \DateTime())->setTimestamp($now))->getRegisterAt()->getTimestamp()
         );
-
-        $this->expectException(\InvalidArgumentException::class);
-        $shipment->setRegisterAt(new \stdClass());
     }
 
     /** @test */

--- a/tests/Unit/ShipmentValidatorTest.php
+++ b/tests/Unit/ShipmentValidatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\AddressInterface;

--- a/tests/Unit/ShopTest.php
+++ b/tests/Unit/ShopTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\AddressInterface;

--- a/tests/Unit/ShopTest.php
+++ b/tests/Unit/ShopTest.php
@@ -128,9 +128,9 @@ class ShopTest extends TestCase
             'id'         => 'shop-id',
             'type'       => 'shops',
             'attributes' => [
-                'name'            => 'MyParcel.com Test Shop',
-                'website'         => 'https://test.shop',
-                'sender_address'  => [
+                'name'           => 'MyParcel.com Test Shop',
+                'website'        => 'https://test.shop',
+                'sender_address' => [
                     'street_1'             => 'Diagonally',
                     'street_2'             => 'Apartment 4',
                     'street_number'        => '2',
@@ -145,7 +145,7 @@ class ShopTest extends TestCase
                     'email'                => 'rob@tables.com',
                     'phone_number'         => '+31 (0)234 567 890',
                 ],
-                'return_address'  => [
+                'return_address' => [
                     'street_1'             => 'Diagonally',
                     'street_2'             => 'Apartment 4',
                     'street_number'        => '4',
@@ -160,7 +160,7 @@ class ShopTest extends TestCase
                     'email'                => 'rob@tables.com',
                     'phone_number'         => '+31 (0)234 567 890',
                 ],
-                'created_at'      => 1509001337,
+                'created_at'     => 1509001337,
             ],
         ], $shop->jsonSerialize());
     }

--- a/tests/Unit/StatusTest.php
+++ b/tests/Unit/StatusTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\StatusInterface;

--- a/tests/Unit/StringUtilsTest.php
+++ b/tests/Unit/StringUtilsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Utils\StringUtils;

--- a/tests/Unit/TaxIdentificationNumberTest.php
+++ b/tests/Unit/TaxIdentificationNumberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Enums\TaxTypeEnum;

--- a/tests/Unit/UrlBuilderTest.php
+++ b/tests/Unit/UrlBuilderTest.php
@@ -18,12 +18,12 @@ class UrlBuilderTest extends TestCase
         $this->assertEquals(['que', 'pasa'], $url->setQuery(['que'])->addQuery(['pasa'])->getQuery());
         $this->assertEquals('torrent', $url->setScheme('torrent')->getScheme());
         $this->assertEquals('guest', $url->setHost('guest')->getHost());
-        $this->assertEquals('Tawny', $url->setPort('Tawny')->getPort());
+        $this->assertEquals(9057, $url->setPort(9057)->getPort());
         $this->assertEquals('GabeN', $url->setUser('GabeN')->getUser());
         $this->assertEquals('hl3c0nf1rm3d', $url->setPassword('hl3c0nf1rm3d')->getPassword());
         $this->assertEquals('/bin', $url->setPath('/bin')->getPath());
         $this->assertEquals('imagination', $url->setFragment('imagination')->getFragment());
 
-        $this->assertEquals('torrent://GabeN@guest:Tawny/bin?0=que&1=pasa#imagination', (string) $url->setPassword(''));
+        $this->assertEquals('torrent://GabeN@guest:9057/bin?0=que&1=pasa#imagination', (string) $url->setPassword(''));
     }
 }

--- a/tests/Unit/UrlBuilderTest.php
+++ b/tests/Unit/UrlBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit;
 
 use MyParcelCom\ApiSdk\Utils\UrlBuilder;

--- a/tests/Unit/Utils/DistanceUtilsTest.php
+++ b/tests/Unit/Utils/DistanceUtilsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyParcelCom\ApiSdk\Tests\Unit\Utils;
 
 use MyParcelCom\ApiSdk\Exceptions\ConversionException;


### PR DESCRIPTION
- Defined parameter types and return types.
- Constructor property promotion.
- Declare strict_types.
- Bumped `symfony/cache` to `5.0` and drop support for PSR-6 cache classes.
- Removed backwards compatibility of `getRegions()` and add `@deprecated`.
- Other various improvements suggested by PhpStorm.
- Fixed tests.