### PR TITLE
🐞 registered-shipments should not have null values in their meta

### DIFF
--- a/src/MyParcelComApi.php
+++ b/src/MyParcelComApi.php
@@ -518,7 +518,7 @@ class MyParcelComApi implements MyParcelComApiInterface
             'post',
             [
                 'data' => $shipment,
-                'meta' => $shipment->getMeta(),
+                'meta' => array_filter($shipment->getMeta()),
             ],
             $this->authenticator->getAuthorizationHeader() + [
                 AuthenticatorInterface::HEADER_ACCEPT => AuthenticatorInterface::MIME_TYPE_JSONAPI,


### PR DESCRIPTION
All users so far probably used this feature with `meta.service_code` but if this is omitted the SDK sends `null` to our API.

For regular shipments, the `meta` was already filtered, so I added this here as well.