### PR TITLE
👌🏻 Use updateCollection() to register the collection

### DIFF
--- a/src/MyParcelComApi.php
+++ b/src/MyParcelComApi.php
@@ -710,7 +710,7 @@ class MyParcelComApi implements MyParcelComApiInterface
             ->setId($collectionId)
             ->setRegister(true);
 
-        return $this->patchResource($collectionToRegister);
+        return $this->updateCollection($collectionToRegister);
     }
 
     /**


### PR DESCRIPTION
Patching a collection should be done via `updateCollection()` since not all properties should be sent to the API.