### PR TITLE
🐛 Fix `TypeError` when setting item weight to `null`

### DIFF
--- a/src/Resources/ShipmentItem.php
+++ b/src/Resources/ShipmentItem.php
@@ -196,7 +196,7 @@ class ShipmentItem implements ShipmentItemInterface
                 throw new MyParcelComException('invalid unit: ' . $unit);
         }
 
-        $this->itemWeight = (int) ceil($weight);
+        $this->itemWeight = $weight === null ? $weight : (int) ceil($weight);
 
         return $this;
     }

--- a/tests/Unit/ShipmentItemTest.php
+++ b/tests/Unit/ShipmentItemTest.php
@@ -81,6 +81,7 @@ class ShipmentItemTest extends TestCase
     {
         $item = new ShipmentItem();
         $this->assertEquals(3000, $item->setItemWeight(3000)->getItemWeight());
+        $this->assertNull($item->setItemWeight(null)->getItemWeight());
     }
 
     /** @test */


### PR DESCRIPTION
The `ceil()` function should not be called when setting the shipment item weight to `null`.