### PR TITLE
🐛 Fix patching a shipment-surcharge

### DIFF
--- a/src/MyParcelComApi.php
+++ b/src/MyParcelComApi.php
@@ -34,6 +34,7 @@ use MyParcelCom\ApiSdk\Resources\ResourceFactory;
 use MyParcelCom\ApiSdk\Resources\Service;
 use MyParcelCom\ApiSdk\Resources\ServiceRate;
 use MyParcelCom\ApiSdk\Resources\Shipment;
+use MyParcelCom\ApiSdk\Resources\ShipmentSurcharge;
 use MyParcelCom\ApiSdk\Shipments\ServiceMatcher;
 use MyParcelCom\ApiSdk\Utils\UrlBuilder;
 use MyParcelCom\ApiSdk\Validators\CollectionValidator;
@@ -805,6 +806,14 @@ class MyParcelComApi implements MyParcelComApiInterface
     }
 
     /**
+     * @see https://api-specification.develop.myparcel.com/#tag/ShipmentSurcharges/paths/~1shipment-surcharges/get
+     */
+    public function getShipmentSurcharges(int $ttl = self::TTL_NO_CACHE): ResourceCollectionInterface
+    {
+        return $this->getRequestCollection($this->apiUri . self::PATH_SHIPMENT_SURCHARGES, $ttl);
+    }
+
+    /**
      * @see https://api-specification.myparcel.com/#tag/ShipmentSurcharges/paths/~1shipment-surcharges~1%7Bshipment_surcharge_id%7D/get
      */
     public function getShipmentSurcharge(
@@ -843,7 +852,11 @@ class MyParcelComApi implements MyParcelComApiInterface
             );
         }
 
-        return $this->patchResource($shipmentSurcharge);
+        // The shipment relationship cannot be patched, so we create a clone without it to get the valid JSON body.
+        $shipmentSurchargeToUpdate = clone $shipmentSurcharge;
+        $shipmentSurchargeToUpdate->setShipment(null);
+
+        return $this->patchResource($shipmentSurchargeToUpdate);
     }
 
     /**

--- a/src/MyParcelComApiInterface.php
+++ b/src/MyParcelComApiInterface.php
@@ -35,6 +35,7 @@ interface MyParcelComApiInterface
     const PATH_SERVICE_RATES = '/service-rates';
     const PATH_SHIPMENTS = '/shipments';
     const PATH_SHIPMENT_STATUSES = '/shipments/{shipment_id}/statuses';
+    const PATH_SHIPMENT_SURCHARGES = '/shipment-surcharges';
     const PATH_SHOPS = '/shops';
 
     const HEADER_IDEMPOTENCY_KEY = 'Idempotency-Key';

--- a/src/Resources/Interfaces/ShipmentSurchargeInterface.php
+++ b/src/Resources/Interfaces/ShipmentSurchargeInterface.php
@@ -24,5 +24,5 @@ interface ShipmentSurchargeInterface extends ResourceInterface
 
     public function getShipment(): ?ShipmentInterface;
 
-    public function setShipment(ShipmentInterface $shipment): self;
+    public function setShipment(?ShipmentInterface $shipment): self;
 }

--- a/src/Resources/Proxy/ShipmentSurchargeProxy.php
+++ b/src/Resources/Proxy/ShipmentSurchargeProxy.php
@@ -70,7 +70,7 @@ class ShipmentSurchargeProxy implements ShipmentSurchargeInterface, ResourceProx
         return $this->getResource()->getShipment();
     }
 
-    public function setShipment(ShipmentInterface $shipment): self
+    public function setShipment(?ShipmentInterface $shipment): self
     {
         return $this->getResource()->setShipment($shipment);
     }

--- a/src/Resources/ShipmentSurcharge.php
+++ b/src/Resources/ShipmentSurcharge.php
@@ -90,7 +90,7 @@ class ShipmentSurcharge implements ShipmentSurchargeInterface
         return $this->relationships['shipment']['data'];
     }
 
-    public function setShipment(ShipmentInterface $shipment): self
+    public function setShipment(?ShipmentInterface $shipment): self
     {
         $this->relationships['shipment']['data'] = $shipment;
 

--- a/tests/Feature/MyParcelComApi/ShipmentSurchargesTest.php
+++ b/tests/Feature/MyParcelComApi/ShipmentSurchargesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MyParcelCom\ApiSdk\Tests\Feature\MyParcelComApi;
 
+use MyParcelCom\ApiSdk\Collection\CollectionInterface;
 use MyParcelCom\ApiSdk\Exceptions\InvalidResourceException;
 use MyParcelCom\ApiSdk\Resources\Interfaces\ShipmentInterface;
 use MyParcelCom\ApiSdk\Resources\Interfaces\ShipmentSurchargeInterface;
@@ -16,6 +17,17 @@ use MyParcelCom\ApiSdk\Tests\TestCase;
  */
 class ShipmentSurchargesTest extends TestCase
 {
+    public function testItRetrievesShipmentSurcharges(): void
+    {
+        $shipmentSurcharges = $this->api->getShipmentSurcharges();
+
+        $this->assertInstanceOf(CollectionInterface::class, $shipmentSurcharges);
+        $this->assertCount(2, $shipmentSurcharges);
+        foreach ($shipmentSurcharges as $shipmentSurcharge) {
+            $this->assertInstanceOf(ShipmentSurchargeInterface::class, $shipmentSurcharge);
+        }
+    }
+
     public function testItRetrievesAShipmentSurcharge(): void
     {
         $shipmentSurcharge = $this->api->getShipmentSurcharge('4afa3758-c425-48bc-96ef-ba43c5da4082');
@@ -53,14 +65,14 @@ class ShipmentSurchargesTest extends TestCase
 
     public function testItUpdatesAShipmentSurcharge(): void
     {
-        $shipmentSurcharge = new ShipmentSurcharge();
-        $shipmentSurcharge->setId('4afa3758-c425-48bc-96ef-ba43c5da4082');
+        $shipmentSurcharge = $this->api->getShipmentSurcharge('4afa3758-c425-48bc-96ef-ba43c5da4082');
         $shipmentSurcharge->setName('updated name');
 
         $updatedShipmentSurcharge = $this->api->updateShipmentSurcharge($shipmentSurcharge);
 
         $this->assertInstanceOf(ShipmentSurchargeInterface::class, $updatedShipmentSurcharge);
         $this->assertEquals('updated name', $updatedShipmentSurcharge->getName());
+        $this->assertEquals($shipmentSurcharge->jsonSerialize(), $updatedShipmentSurcharge->jsonSerialize());
     }
 
     public function testItCannotUpdateAShipmentSurchargeWithoutAnId(): void

--- a/tests/Stubs/get/https---api-shipment-surcharges/page-number--1/page-size--100.json
+++ b/tests/Stubs/get/https---api-shipment-surcharges/page-number--1/page-size--100.json
@@ -1,0 +1,67 @@
+{
+  "data": [
+    {
+      "id": "4afa3758-c425-48bc-96ef-ba43c5da4082",
+      "type": "shipment-surcharges",
+      "attributes": {
+        "name": "test",
+        "description": "desc",
+        "fee": {
+          "amount": 123,
+          "currency": "ALL"
+        },
+        "created_at": 1726674123,
+        "updated_at": 1726674123
+      },
+      "links": {
+        "self": "https://api/shipment-surcharges/4afa3758-c425-48bc-96ef-ba43c5da4082"
+      },
+      "relationships": {
+        "shipment": {
+          "data": {
+            "id": "shipment-id-1",
+            "type": "shipments"
+          },
+          "links": {
+            "related": "https://api/shipments/shipment-id-1"
+          }
+        }
+      }
+    },
+    {
+      "id": "ff772f9d-ca39-4315-84b1-eac317b6001f",
+      "type": "shipment-surcharges",
+      "attributes": {
+        "name": "asdasd",
+        "fee": {
+          "amount": 345,
+          "currency": "AMD"
+        },
+        "created_at": 1726674132,
+        "updated_at": 1726674132
+      },
+      "links": {
+        "self": "https://api/shipment-surcharges/ff772f9d-ca39-4315-84b1-eac317b6001f"
+      },
+      "relationships": {
+        "shipment": {
+          "data": {
+            "id": "shipment-id-1",
+            "type": "shipments"
+          },
+          "links": {
+            "related": "https://api/shipments/shipment-id-1"
+          }
+        }
+      }
+    }
+  ],
+  "meta": {
+    "total_pages": 1,
+    "total_records": 2
+  },
+  "links": {
+    "self": "https://api/shipment-surcharges?page[size]=100&page[number]=1",
+    "first": "https://api/shipment-surcharges?page[size]=100&page[number]=1"
+  }
+}


### PR DESCRIPTION
The `shipment` relationship cannot be patched (API returns error) so it should be removed from the request body.

I also added a helper method to get all shipment surcharges.