### PR TITLE
✨ Allow ServiceOptions to have values

### DIFF
--- a/docker/php8/Dockerfile
+++ b/docker/php8/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2.25-cli
+FROM php:8.3.13-cli
 
 RUN apt-get update \
     && apt-get install -y curl zip unzip software-properties-common gettext-base iproute2 \

--- a/src/Resources/Interfaces/ServiceOptionInterface.php
+++ b/src/Resources/Interfaces/ServiceOptionInterface.php
@@ -29,4 +29,8 @@ interface ServiceOptionInterface extends ResourceInterface
     public function setIncluded(bool $included): self;
 
     public function isIncluded(): bool;
+
+    public function setValues(?array $values): self;
+
+    public function getValues(): ?array;
 }

--- a/src/Resources/Interfaces/ServiceOptionInterface.php
+++ b/src/Resources/Interfaces/ServiceOptionInterface.php
@@ -18,6 +18,10 @@ interface ServiceOptionInterface extends ResourceInterface
 
     public function getCategory(): ?string;
 
+    public function setValuesFormat(?array $valuesFormat): self;
+
+    public function getValuesFormat(): ?array;
+
     public function setPrice(?int $price): self;
 
     public function getPrice(): ?int;

--- a/src/Resources/Interfaces/ServiceOptionInterface.php
+++ b/src/Resources/Interfaces/ServiceOptionInterface.php
@@ -20,6 +20,9 @@ interface ServiceOptionInterface extends ResourceInterface
 
     public function setValuesFormat(?array $valuesFormat): self;
 
+    /**
+     * Defines if this ServiceOption requires a `values` array to be set when using it to create a shipment.
+     */
     public function getValuesFormat(): ?array;
 
     public function setPrice(?int $price): self;
@@ -34,6 +37,10 @@ interface ServiceOptionInterface extends ResourceInterface
 
     public function isIncluded(): bool;
 
+    /**
+     * When adding a ServiceOption to a Shipment, it might require values such as an `amount` and a `currency`.
+     * This is defined in the `values_format` of the ServiceOption, which returns these requirements as JSON Schema.
+     */
     public function setValues(?array $values): self;
 
     public function getValues(): ?array;

--- a/src/Resources/Proxy/ServiceOptionProxy.php
+++ b/src/Resources/Proxy/ServiceOptionProxy.php
@@ -78,6 +78,18 @@ class ServiceOptionProxy implements ServiceOptionInterface, ResourceProxyInterfa
         return $this->getResource()->getCategory();
     }
 
+    public function setValuesFormat(?array $valuesFormat): self
+    {
+        $this->getResource()->setValuesFormat($valuesFormat);
+
+        return $this;
+    }
+
+    public function getValuesFormat(): ?array
+    {
+        return $this->getResource()->getValuesFormat();
+    }
+
     public function setPrice(?int $price): self
     {
         $this->meta[self::META_PRICE][self::META_PRICE_AMOUNT] = $price;

--- a/src/Resources/Proxy/ServiceOptionProxy.php
+++ b/src/Resources/Proxy/ServiceOptionProxy.php
@@ -25,17 +25,21 @@ class ServiceOptionProxy implements ServiceOptionInterface, ResourceProxyInterfa
     const META_PRICE_AMOUNT = 'amount';
     const META_PRICE_CURRENCY = 'currency';
     const META_INCLUDED = 'included';
+    const META_VALUES = 'values';
 
     private ?string $id = null;
 
     private string $type = ResourceInterface::TYPE_SERVICE_OPTION;
 
     private array $meta = [
+        // Relationships returned from the service-rates endpoints can have a price and indication if they are included.
         self::META_PRICE    => [
             self::META_PRICE_AMOUNT   => null,
             self::META_PRICE_CURRENCY => null,
         ],
         self::META_INCLUDED => null,
+        // Relationships returned from the shipment endpoints can have values (according to the defined values_format).
+        self::META_VALUES => null,
     ];
 
     public function setName(string $name): self
@@ -108,6 +112,18 @@ class ServiceOptionProxy implements ServiceOptionInterface, ResourceProxyInterfa
     public function isIncluded(): bool
     {
         return (bool) $this->meta[self::META_INCLUDED];
+    }
+
+    public function setValues(?array $values): self
+    {
+        $this->meta[self::META_VALUES] = $values;
+
+        return $this;
+    }
+
+    public function getValues(): ?array
+    {
+        return $this->meta[self::META_VALUES];
     }
 
     /**

--- a/src/Resources/ResourceFactory.php
+++ b/src/Resources/ResourceFactory.php
@@ -223,6 +223,24 @@ class ResourceFactory implements ResourceFactoryInterface, ResourceProxyInterfac
             unset($data['attributes']['recipient_tax_identification_numbers']);
         }
 
+        if (isset($data['relationships']['service_options'])) {
+            $serviceOptions = $data['relationships']['service_options']['data'];
+
+            foreach ($serviceOptions as $serviceOption) {
+                $serviceOptionProxy = (new ServiceOptionProxy())
+                    ->setMyParcelComApi($this->api)
+                    ->setId($serviceOption['id']);
+
+                if (isset($serviceOption['meta']['values'])) {
+                    $serviceOptionProxy->setValues($serviceOption['meta']['values']);
+                }
+
+                $shipment->addServiceOption($serviceOptionProxy);
+            }
+
+            unset($data['relationships']['service_options']);
+        }
+
         return $shipment;
     }
 

--- a/src/Resources/ServiceOption.php
+++ b/src/Resources/ServiceOption.php
@@ -22,6 +22,7 @@ class ServiceOption implements ServiceOptionInterface
     const META_PRICE_AMOUNT = 'amount';
     const META_PRICE_CURRENCY = 'currency';
     const META_INCLUDED = 'included';
+    const META_VALUES = 'values';
 
     private ?string $id = null;
 
@@ -34,11 +35,14 @@ class ServiceOption implements ServiceOptionInterface
     ];
 
     private array $meta = [
+        // Relationships posted to the service-rates endpoints can have a price and indication if they are included.
         self::META_PRICE    => [
             self::META_PRICE_AMOUNT   => null,
             self::META_PRICE_CURRENCY => null,
         ],
         self::META_INCLUDED => null,
+        // Relationships posted to the shipment endpoints can have values (according to the defined values_format).
+        self::META_VALUES => null,
     ];
 
     public function setName(string $name): self
@@ -111,5 +115,17 @@ class ServiceOption implements ServiceOptionInterface
     public function isIncluded(): bool
     {
         return (bool) $this->meta[self::META_INCLUDED];
+    }
+
+    public function setValues(?array $values): self
+    {
+        $this->meta[self::META_VALUES] = $values;
+
+        return $this;
+    }
+
+    public function getValues(): ?array
+    {
+        return $this->meta[self::META_VALUES];
     }
 }

--- a/src/Resources/ServiceOption.php
+++ b/src/Resources/ServiceOption.php
@@ -17,6 +17,7 @@ class ServiceOption implements ServiceOptionInterface
     const ATTRIBUTE_NAME = 'name';
     const ATTRIBUTE_CODE = 'code';
     const ATTRIBUTE_CATEGORY = 'category';
+    const ATTRIBUTE_VALUES_FORMAT = 'values_format';
 
     const META_PRICE = 'price';
     const META_PRICE_AMOUNT = 'amount';
@@ -29,9 +30,10 @@ class ServiceOption implements ServiceOptionInterface
     private string $type = ResourceInterface::TYPE_SERVICE_OPTION;
 
     private array $attributes = [
-        self::ATTRIBUTE_NAME     => null,
-        self::ATTRIBUTE_CODE     => null,
-        self::ATTRIBUTE_CATEGORY => null,
+        self::ATTRIBUTE_NAME          => null,
+        self::ATTRIBUTE_CODE          => null,
+        self::ATTRIBUTE_CATEGORY      => null,
+        self::ATTRIBUTE_VALUES_FORMAT => null,
     ];
 
     private array $meta = [
@@ -42,7 +44,7 @@ class ServiceOption implements ServiceOptionInterface
         ],
         self::META_INCLUDED => null,
         // Relationships posted to the shipment endpoints can have values (according to the defined values_format).
-        self::META_VALUES => null,
+        self::META_VALUES   => null,
     ];
 
     public function setName(string $name): self
@@ -79,6 +81,18 @@ class ServiceOption implements ServiceOptionInterface
     public function getCategory(): ?string
     {
         return $this->attributes[self::ATTRIBUTE_CATEGORY];
+    }
+
+    public function setValuesFormat(?array $valuesFormat): self
+    {
+        $this->attributes[self::ATTRIBUTE_VALUES_FORMAT] = $valuesFormat;
+
+        return $this;
+    }
+
+    public function getValuesFormat(): ?array
+    {
+        return $this->attributes[self::ATTRIBUTE_VALUES_FORMAT];
     }
 
     public function setPrice(?int $price): self

--- a/src/Resources/Traits/JsonSerializable.php
+++ b/src/Resources/Traits/JsonSerializable.php
@@ -15,14 +15,14 @@ trait JsonSerializable
     {
         $json = $this->arrayValuesToArray(get_object_vars($this));
 
-        // We remove all empty properties
+        // Remove all empty top-level properties (id, attributes, relationships, meta).
         foreach ($json as $property => $value) {
             if ($this->isEmpty($value)) {
                 unset($json[$property]);
             }
         }
 
-        // If there are attributes, we make sure no empty attributes are serialized
+        // If there are attributes, make sure no empty properties are serialized.
         if (isset($json['attributes'])) {
             foreach ($json['attributes'] as $attribute => $value) {
                 if ($this->isEmpty($value)) {
@@ -31,11 +31,19 @@ trait JsonSerializable
             }
         }
 
-        // If there are relationships, we remove any possible attributes still
-        // present. This can happen when a resource (not a proxy) is set as a
-        // relationship on another resource.
+        // If there are relationships, remove any possible 'attributes' still present on the related resource.
+        // This can happen when a resource (not a proxy) is set as a relationship on another resource.
         if (isset($json['relationships'])) {
             $json['relationships'] = $this->removeRelationshipAttributes($json['relationships']);
+        }
+
+        // If there is a meta, make sure no empty properties are serialized
+        if (isset($json['meta'])) {
+            foreach ($json['meta'] as $attribute => $value) {
+                if ($this->isEmpty($value)) {
+                    unset($json['meta'][$attribute]);
+                }
+            }
         }
 
         return $json;

--- a/src/Resources/Traits/ProcessIncludes.php
+++ b/src/Resources/Traits/ProcessIncludes.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MyParcelCom\ApiSdk\Resources\Traits;
 
 use MyParcelCom\ApiSdk\Resources\Interfaces\ResourceInterface;
+use MyParcelCom\ApiSdk\Resources\Interfaces\ResourceProxyInterface;
 
 trait ProcessIncludes
 {
@@ -28,13 +29,21 @@ trait ProcessIncludes
             if (is_array($relationship)) {
                 foreach ($relationship as $index => $item) {
                     if ($resource->getType() === $item->getType() && $resource->getId() === $item->getId()) {
-                        $this->relationships[$relationshipKey]['data'][$index] = $resource;
+                        if ($this->relationships[$relationshipKey]['data'][$index] instanceof ResourceProxyInterface) {
+                            $this->relationships[$relationshipKey]['data'][$index]->setResource($resource);
+                        } else {
+                            $this->relationships[$relationshipKey]['data'][$index] = $resource;
+                        }
                         break;
                     }
                 }
             } else {
                 if ($resource->getType() === $relationship->getType() && $resource->getId() === $relationship->getId()) {
-                    $this->relationships[$relationshipKey]['data'] = $resource;
+                    if ($this->relationships[$relationshipKey]['data'] instanceof ResourceProxyInterface) {
+                        $this->relationships[$relationshipKey]['data']->setResource($resource);
+                    } else {
+                        $this->relationships[$relationshipKey]['data'] = $resource;
+                    }
                 }
             }
         }

--- a/src/Resources/Traits/ProxiesResource.php
+++ b/src/Resources/Traits/ProxiesResource.php
@@ -31,6 +31,13 @@ trait ProxiesResource
         return $this;
     }
 
+    public function setResource(ResourceInterface $resource): self
+    {
+        $this->resource = $resource;
+
+        return $this;
+    }
+
     /**
      * Get the resource that this instance is a proxy for.
      */

--- a/tests/Feature/Proxy/ServiceOptionProxyTest.php
+++ b/tests/Feature/Proxy/ServiceOptionProxyTest.php
@@ -4,37 +4,29 @@ declare(strict_types=1);
 
 namespace MyParcelCom\ApiSdk\Tests\Feature\Proxy;
 
-use MyParcelCom\ApiSdk\Authentication\AuthenticatorInterface;
 use MyParcelCom\ApiSdk\MyParcelComApi;
 use MyParcelCom\ApiSdk\MyParcelComApiInterface;
 use MyParcelCom\ApiSdk\Resources\Interfaces\ResourceInterface;
 use MyParcelCom\ApiSdk\Resources\Proxy\ServiceOptionProxy;
 use MyParcelCom\ApiSdk\Tests\Traits\MocksApiCommunication;
 use PHPUnit\Framework\TestCase;
-use Psr\Http\Client\ClientInterface;
 
 class ServiceOptionProxyTest extends TestCase
 {
     use MocksApiCommunication;
 
-    /** @var ClientInterface */
-    private $client;
-    /** @var AuthenticatorInterface */
-    private $authenticator;
-    /** @var MyParcelComApiInterface */
-    private $api;
-    /** @var ServiceOptionProxy */
-    private $serviceOptionProxy;
+    private MyParcelComApiInterface $api;
+    private ServiceOptionProxy $serviceOptionProxy;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->client = $this->getClientMock();
-        $this->authenticator = $this->getAuthenticatorMock();
-        $this->api = (new MyParcelComApi('https://api', $this->client))
+        $client = $this->getClientMock();
+        $authenticator = $this->getAuthenticatorMock();
+        $this->api = (new MyParcelComApi('https://api', $client))
             ->setCache($this->getNullCache())
-            ->authenticate($this->authenticator);
+            ->authenticate($authenticator);
 
         $this->serviceOptionProxy = (new ServiceOptionProxy())
             ->setMyParcelComApi($this->api)
@@ -45,9 +37,18 @@ class ServiceOptionProxyTest extends TestCase
     public function testAccessors()
     {
         $this->assertEquals('Drone delivery', $this->serviceOptionProxy->setName('Drone delivery')->getName());
-        $this->assertEquals('delivery-method', $this->serviceOptionProxy->setCategory('delivery-method')->getCategory());
-        $this->assertEquals('delivery-method-drone', $this->serviceOptionProxy->setCode('delivery-method-drone')->getCode());
-        $this->assertEquals('an-id-for-a-service-option', $this->serviceOptionProxy->setId('an-id-for-a-service-option')->getId());
+        $this->assertEquals(
+            'delivery-method',
+            $this->serviceOptionProxy->setCategory('delivery-method')->getCategory(),
+        );
+        $this->assertEquals(
+            'delivery-method-drone',
+            $this->serviceOptionProxy->setCode('delivery-method-drone')->getCode(),
+        );
+        $this->assertEquals(
+            'an-id-for-a-service-option',
+            $this->serviceOptionProxy->setId('an-id-for-a-service-option')->getId(),
+        );
     }
 
     /** @test */
@@ -71,6 +72,9 @@ class ServiceOptionProxyTest extends TestCase
 
         $this->assertFalse($this->serviceOptionProxy->isIncluded());
         $this->assertTrue($this->serviceOptionProxy->setIncluded(true)->isIncluded());
+
+        $this->assertNull($this->serviceOptionProxy->getValues());
+        $this->assertEquals(['val'], $this->serviceOptionProxy->setValues(['val'])->getValues());
     }
 
     /** @test */
@@ -108,7 +112,8 @@ class ServiceOptionProxyTest extends TestCase
             ->setId('service-option-id-1')
             ->setIncluded(false)
             ->setPrice(500)
-            ->setCurrency('GBP');
+            ->setCurrency('GBP')
+            ->setValues(['val']);
 
         $this->assertEquals([
             'id'   => 'service-option-id-1',
@@ -119,6 +124,7 @@ class ServiceOptionProxyTest extends TestCase
                     'amount'   => 500,
                     'currency' => 'GBP',
                 ],
+                'values'   => ['val'],
             ],
         ], $serviceProxy->jsonSerialize());
     }

--- a/tests/Feature/Proxy/ServiceOptionProxyTest.php
+++ b/tests/Feature/Proxy/ServiceOptionProxyTest.php
@@ -36,10 +36,17 @@ class ServiceOptionProxyTest extends TestCase
     /** @test */
     public function testAccessors()
     {
-        $this->assertEquals('Drone delivery', $this->serviceOptionProxy->setName('Drone delivery')->getName());
+        $this->assertEquals(
+            'Drone delivery',
+            $this->serviceOptionProxy->setName('Drone delivery')->getName(),
+        );
         $this->assertEquals(
             'delivery-method',
             $this->serviceOptionProxy->setCategory('delivery-method')->getCategory(),
+        );
+        $this->assertEquals(
+            ['json' => 'schema'],
+            $this->serviceOptionProxy->setValuesFormat(['json' => 'schema'])->getValuesFormat(),
         );
         $this->assertEquals(
             'delivery-method-drone',
@@ -58,6 +65,20 @@ class ServiceOptionProxyTest extends TestCase
         $this->assertEquals('Collection', $this->serviceOptionProxy->getName());
         $this->assertEquals('handover-method', $this->serviceOptionProxy->getCategory());
         $this->assertEquals('handover-method-collection', $this->serviceOptionProxy->getCode());
+        $this->assertEquals(
+            [
+                'required'   => ['amount', 'currency'],
+                'properties' => [
+                    'amount'   => [
+                        'type' => 'integer',
+                    ],
+                    'currency' => [
+                        'type' => 'string',
+                    ],
+                ],
+            ],
+            $this->serviceOptionProxy->getValuesFormat(),
+        );
         $this->assertEquals('d4637e6a-4b7a-44c8-8b4d-8311d0cf1238', $this->serviceOptionProxy->getId());
     }
 

--- a/tests/Stubs/get/https---api-service-options-d4637e6a-4b7a-44c8-8b4d-8311d0cf1238.json
+++ b/tests/Stubs/get/https---api-service-options-d4637e6a-4b7a-44c8-8b4d-8311d0cf1238.json
@@ -5,7 +5,21 @@
     "attributes": {
       "name": "Collection",
       "category": "handover-method",
-      "code": "handover-method-collection"
+      "code": "handover-method-collection",
+      "values_format": {
+        "required": [
+          "amount",
+          "currency"
+        ],
+        "properties": {
+          "amount": {
+            "type": "integer"
+          },
+          "currency": {
+            "type": "string"
+          }
+        }
+      }
     }
   }
 }

--- a/tests/Stubs/get/https---api-shipments-shipment-id-1.json
+++ b/tests/Stubs/get/https---api-shipments-shipment-id-1.json
@@ -166,7 +166,13 @@
         "data": [
           {
             "type": "service-options",
-            "id": "service-option-id-1"
+            "id": "service-option-id-1",
+            "meta": {
+              "values": {
+                "amount": 100,
+                "currency": "GBP"
+              }
+            }
           }
         ]
       },

--- a/tests/Stubs/get/https---api-shipments-shipment-id-1/include-shop,shipment_status,contract,service,service_options,files,shipment_surcharges.json
+++ b/tests/Stubs/get/https---api-shipments-shipment-id-1/include-shop,shipment_status,contract,service,service_options,files,shipment_surcharges.json
@@ -166,7 +166,13 @@
         "data": [
           {
             "type": "service-options",
-            "id": "service-option-id-1"
+            "id": "service-option-id-1",
+            "meta": {
+              "values": {
+                "amount": 100,
+                "currency": "GBP"
+              }
+            }
           }
         ]
       },

--- a/tests/Stubs/get/https---api-shipments/include-shop,shipment_status,contract,service,service_options,files,shipment_surcharges/filter-shop--shop-id-1/page-number--1/page-size--100.json
+++ b/tests/Stubs/get/https---api-shipments/include-shop,shipment_status,contract,service,service_options,files,shipment_surcharges/filter-shop--shop-id-1/page-number--1/page-size--100.json
@@ -152,7 +152,13 @@
           "data": [
             {
               "type": "service-options",
-              "id": "service-option-id-1"
+              "id": "service-option-id-1",
+              "meta": {
+                "values": {
+                  "amount": 100,
+                  "currency": "GBP"
+                }
+              }
             }
           ]
         },

--- a/tests/Stubs/get/https---api-shipments/include-shop,shipment_status,contract,service,service_options,files,shipment_surcharges/page-number--1/page-size--100.json
+++ b/tests/Stubs/get/https---api-shipments/include-shop,shipment_status,contract,service,service_options,files,shipment_surcharges/page-number--1/page-size--100.json
@@ -167,7 +167,13 @@
           "data": [
             {
               "type": "service-options",
-              "id": "service-option-id-1"
+              "id": "service-option-id-1",
+              "meta": {
+                "values": {
+                  "amount": 100,
+                  "currency": "GBP"
+                }
+              }
             }
           ]
         },

--- a/tests/Unit/Resources/ServiceOptionTest.php
+++ b/tests/Unit/Resources/ServiceOptionTest.php
@@ -45,6 +45,13 @@ class ServiceOptionTest extends TestCase
     }
 
     /** @test */
+    public function testValuesFormat(): void
+    {
+        $option = new ServiceOption();
+        $this->assertEquals(['json' => 'schema'], $option->setValuesFormat(['json' => 'schema'])->getValuesFormat());
+    }
+
+    /** @test */
     public function testItSetsAndGetsPrice(): void
     {
         $option = new ServiceOption();
@@ -85,18 +92,18 @@ class ServiceOptionTest extends TestCase
             ->setName('Sign on delivery')
             ->setCode('some-code')
             ->setCategory('some-category')
-            ->setValues(['val']);
+            ->setValuesFormat(['json' => 'schema']);
 
         $this->assertEquals([
             'id'         => 'service-option-id',
             'type'       => 'service-options',
             'attributes' => [
-                'name'     => 'Sign on delivery',
-                'code'     => 'some-code',
-                'category' => 'some-category',
-            ],
-            'meta'       => [
-                'values' => ['val'],
+                'name'          => 'Sign on delivery',
+                'code'          => 'some-code',
+                'category'      => 'some-category',
+                'values_format' => [
+                    'json' => 'schema',
+                ],
             ],
         ], $option->jsonSerialize());
     }

--- a/tests/Unit/Resources/ServiceOptionTest.php
+++ b/tests/Unit/Resources/ServiceOptionTest.php
@@ -10,42 +10,42 @@ use PHPUnit\Framework\TestCase;
 class ServiceOptionTest extends TestCase
 {
     /** @test */
-    public function testId()
+    public function testId(): void
     {
         $option = new ServiceOption();
         $this->assertEquals('service-option-id', $option->setId('service-option-id')->getId());
     }
 
     /** @test */
-    public function testType()
+    public function testType(): void
     {
         $option = new ServiceOption();
         $this->assertEquals('service-options', $option->getType());
     }
 
     /** @test */
-    public function testName()
+    public function testName(): void
     {
         $option = new ServiceOption();
         $this->assertEquals('Sign on delivery', $option->setName('Sign on delivery')->getName());
     }
 
     /** @test */
-    public function testCode()
+    public function testCode(): void
     {
         $option = new ServiceOption();
         $this->assertEquals('some-code', $option->setCode('some-code')->getCode());
     }
 
     /** @test */
-    public function testCategory()
+    public function testCategory(): void
     {
         $option = new ServiceOption();
         $this->assertEquals('some-category', $option->setCategory('some-category')->getCategory());
     }
 
     /** @test */
-    public function testItSetsAndGetsPrice()
+    public function testItSetsAndGetsPrice(): void
     {
         $option = new ServiceOption();
         $this->assertNull($option->getPrice());
@@ -53,7 +53,7 @@ class ServiceOptionTest extends TestCase
     }
 
     /** @test */
-    public function testItSetsAndGetsCurrency()
+    public function testItSetsAndGetsCurrency(): void
     {
         $option = new ServiceOption();
         $this->assertNull($option->getCurrency());
@@ -61,7 +61,7 @@ class ServiceOptionTest extends TestCase
     }
 
     /** @test */
-    public function testItSetsAndGetsIncluded()
+    public function testItSetsAndGetsIncluded(): void
     {
         $option = new ServiceOption();
         $this->assertFalse($option->isIncluded());
@@ -69,13 +69,23 @@ class ServiceOptionTest extends TestCase
     }
 
     /** @test */
-    public function testJsonSerialize()
+    public function testItSetsAndGetsValues(): void
+    {
+        $option = new ServiceOption();
+        $this->assertNull($option->getValues());
+        $this->assertEquals(['val'], $option->setValues(['val'])->getValues());
+        $this->assertNull($option->setValues(null)->getValues());
+    }
+
+    /** @test */
+    public function testJsonSerialize(): void
     {
         $option = (new ServiceOption())
             ->setId('service-option-id')
             ->setName('Sign on delivery')
             ->setCode('some-code')
-            ->setCategory('some-category');
+            ->setCategory('some-category')
+            ->setValues(['val']);
 
         $this->assertEquals([
             'id'         => 'service-option-id',
@@ -84,6 +94,9 @@ class ServiceOptionTest extends TestCase
                 'name'     => 'Sign on delivery',
                 'code'     => 'some-code',
                 'category' => 'some-category',
+            ],
+            'meta'       => [
+                'values' => ['val'],
             ],
         ], $option->jsonSerialize());
     }


### PR DESCRIPTION
- `ServiceOption` models can have values when added to a `Shipment` (used when posting new shipments).
- `ServiceOptionProxy` models can have values when populated on a `Shipment` (used when getting shipments).
- When the `ResourceFactory` is populating included resources, it needs to respect existing `Proxy` relationships.
- Added tests.