### PR TITLE
🪳 Avoid read-only relationships in POST requests

### DIFF
--- a/src/MyParcelComApi.php
+++ b/src/MyParcelComApi.php
@@ -385,7 +385,7 @@ class MyParcelComApi implements MyParcelComApiInterface
         ShipmentInterface|array $shipmentData,
         ?ServiceRateInterface $dynamicServiceRate = null,
     ): array {
-        $data = ($shipmentData instanceof ShipmentInterface) ? $shipmentData->jsonSerialize() : $shipmentData;
+        $data = ($shipmentData instanceof ShipmentInterface) ? $shipmentData->getData() : $shipmentData;
 
         if (!isset($data['relationships'])) {
             $data['relationships'] = [];
@@ -584,7 +584,7 @@ class MyParcelComApi implements MyParcelComApiInterface
             '/registered-shipments?' . http_build_query(['include' => Shipment::RELATIONSHIP_FILES]),
             'post',
             [
-                'data' => $shipment,
+                'data' => $shipment->getData(),
                 'meta' => array_filter($shipment->getMeta()),
             ],
             $this->authenticator->getAuthorizationHeader() + [
@@ -648,7 +648,7 @@ class MyParcelComApi implements MyParcelComApiInterface
             ]),
             'post',
             [
-                'data' => $shipment,
+                'data' => $shipment->getData(),
                 'meta' => array_merge(
                     [
                         'colli' => array_map(

--- a/src/Resources/Proxy/ShipmentProxy.php
+++ b/src/Resources/Proxy/ShipmentProxy.php
@@ -40,6 +40,11 @@ class ShipmentProxy implements ShipmentInterface, ResourceProxyInterface
 
     private string $type = ResourceInterface::TYPE_SHIPMENT;
 
+    public function getData(): array
+    {
+        return $this->getResource()->getData();
+    }
+
     public function getMeta(): array
     {
         return $this->getResource()->getMeta();

--- a/src/Resources/Shipment.php
+++ b/src/Resources/Shipment.php
@@ -163,6 +163,22 @@ class Shipment implements ShipmentInterface
     /** @var callable */
     private $statusHistoryCallback = null;
 
+    /**
+     * Prepare the data for a request to our API. This filters the read-only relationships to avoid validation errors.
+     */
+    public function getData(): array
+    {
+        $data = $this->jsonSerialize();
+
+        // Remove read-only relationships.
+        unset($data['relationships']['colli']);
+        unset($data['relationships']['files']);
+        unset($data['relationships']['shipment_status']);
+        unset($data['relationships']['shipment_surcharges']);
+
+        return $data;
+    }
+
     public function getMeta(): array
     {
         return $this->meta;


### PR DESCRIPTION
Posting shipment data to the dynamic-service-rates endpoint caused api-specification errors on the colli relationship.

This relationship was set using `setColli()` or `addCollo()` but the `Shipment` models did not have an `id` (of course).
This made our automatic validation trigger a missing `id` in relationship error.

We assume errors to this endpoint are caused by the carrier, so we ignore the rate if it cannot be resolved.
However, in this case our system was always throwing an error, causing dynamic multi-colli rates to always be empty.