### PR TITLE
Allow `psr/http-message` v2 to increase compatibility with other packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "myclabs/php-enum": "^1.5",
     "php-http/discovery": "^1.5",
     "php-http/httplug": ">=1.1",
-    "psr/http-message": "^1.0",
+    "psr/http-message": "^1.0 || ^2.0",
     "psr/simple-cache": "^1.0",
     "symfony/cache": ">=5.0",
     "setasign/fpdf": "^1.8",


### PR DESCRIPTION
Some major packages require v2 of `psr/http-message`, such as `aws/aws-sdk-php` and `elasticsearch/elasticsearch`. 

Since v2 only adds return types it is considered compatible which is also reflected by other packages having the psr/http-message constraint defined as `^1.0 || ^2.0` such as [guzzlehttp/psr7](https://packagist.org/packages/guzzlehttp/psr7) or https://packagist.org/packages/predis/predis

# Links
- [psr/http-message v2 release](https://github.com/php-fig/http-message/releases/tag/2.0)
- [Diff between v1.1 and v2](https://github.com/php-fig/http-message/compare/1.1...2.0)