### PR TITLE
♻️ Define `StreamInterface` return types and properly mock `getBody`

### DIFF
--- a/src/Resources/Proxy/FileStreamProxy.php
+++ b/src/Resources/Proxy/FileStreamProxy.php
@@ -79,7 +79,7 @@ class FileStreamProxy implements StreamInterface
      *
      * @return int|null Returns the size in bytes if known, or null if unknown.
      */
-    public function getSize()
+    public function getSize(): ?int
     {
         return $this->getStream()->getSize();
     }
@@ -90,7 +90,7 @@ class FileStreamProxy implements StreamInterface
      * @return int Position of the file pointer
      * @throws \RuntimeException on error.
      */
-    public function tell()
+    public function tell(): int
     {
         return $this->getStream()->tell();
     }
@@ -123,9 +123,9 @@ class FileStreamProxy implements StreamInterface
      *                    SEEK_END: Set position to end-of-stream plus offset.
      * @throws \RuntimeException on failure.
      */
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek($offset, $whence = SEEK_SET): void
     {
-        return $this->getStream()->seek($offset, $whence);
+        $this->getStream()->seek($offset, $whence);
     }
 
     /**
@@ -138,9 +138,9 @@ class FileStreamProxy implements StreamInterface
      * @link http://www.php.net/manual/en/function.fseek.php
      * @see  seek()
      */
-    public function rewind()
+    public function rewind(): void
     {
-        return $this->getStream()->rewind();
+        $this->getStream()->rewind();
     }
 
     /**
@@ -158,7 +158,7 @@ class FileStreamProxy implements StreamInterface
      * @return int Returns the number of bytes written to the stream.
      * @throws \RuntimeException on failure.
      */
-    public function write($string)
+    public function write($string): int
     {
         return $this->getStream()->write($string);
     }
@@ -181,7 +181,7 @@ class FileStreamProxy implements StreamInterface
      *                    if no bytes are available.
      * @throws \RuntimeException if an error occurs.
      */
-    public function read($length)
+    public function read($length): string
     {
         return $this->getStream()->read($length);
     }
@@ -193,7 +193,7 @@ class FileStreamProxy implements StreamInterface
      * @throws \RuntimeException if unable to read or an error occurs while
      *     reading.
      */
-    public function getContents()
+    public function getContents(): string
     {
         return $this->getStream()->getContents();
     }

--- a/src/Resources/Shipment.php
+++ b/src/Resources/Shipment.php
@@ -171,10 +171,10 @@ class Shipment implements ShipmentInterface
         $data = $this->jsonSerialize();
 
         // Remove read-only relationships.
-        unset($data['relationships']['colli']);
-        unset($data['relationships']['files']);
-        unset($data['relationships']['shipment_status']);
-        unset($data['relationships']['shipment_surcharges']);
+        unset($data['relationships'][self::RELATIONSHIP_COLLI]);
+        unset($data['relationships'][self::RELATIONSHIP_FILES]);
+        unset($data['relationships'][self::RELATIONSHIP_STATUS]);
+        unset($data['relationships'][self::RELATIONSHIP_SHIPMENT_SURCHARGES]);
 
         return $data;
     }

--- a/tests/Unit/Authentication/ClientCredentialsTest.php
+++ b/tests/Unit/Authentication/ClientCredentialsTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 
 class ClientCredentialsTest extends TestCase
 {
@@ -41,11 +42,14 @@ class ClientCredentialsTest extends TestCase
             ->getMock();
         $this->response->method('getBody')
             ->willReturnCallback(function () {
-                return json_encode([
+                $streamMock = $this->createMock(StreamInterface::class);
+                $streamMock->method('__toString')->willReturn(json_encode([
                     'token_type'   => 'Bearer',
                     'expires_in'   => 86400,
                     'access_token' => 'an-access-token-for-the-myparcelcom-api-' . $this->tokenSuffix,
-                ]);
+                ]));
+
+                return $streamMock;
             });
         $this->response->method('getStatusCode')
             ->willReturn(200);

--- a/tests/Unit/Collection/RequestCollectionTest.php
+++ b/tests/Unit/Collection/RequestCollectionTest.php
@@ -9,6 +9,7 @@ use MyParcelCom\ApiSdk\Collection\RequestCollection;
 use MyParcelCom\ApiSdk\Resources\Interfaces\ResourceInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 
 class RequestCollectionTest extends TestCase
 {
@@ -29,8 +30,10 @@ class RequestCollectionTest extends TestCase
             $this->pageNumber = $pageNumber;
             $this->pageSize = $pageSize;
 
+            $streamMock = $this->createMock(StreamInterface::class);
+            $streamMock->method('__toString')->willReturn('{"data": "something something", "meta": {"total_records": 123}}');
             $response = $this->createMock(ResponseInterface::class);
-            $response->method('getBody')->willReturn('{"data": "something something", "meta": {"total_records": 123}}');
+            $response->method('getBody')->willReturn($streamMock);
 
             return $response;
         };


### PR DESCRIPTION
After merging https://github.com/MyParcelCOM/api-sdk-php/pull/246 the pipelines failed. To use the v2 version of `psr/http-message` we have to define the return types (this is backwards compatible with v1) and we have to properly mock `getBody` in our tests.