### PR TITLE
🧑‍💻 Ignore protocol difference when prepending URL

### DIFF
--- a/src/MyParcelComApi.php
+++ b/src/MyParcelComApi.php
@@ -1148,7 +1148,7 @@ class MyParcelComApi implements MyParcelComApiInterface
         array $headers = [],
         $ttl = self::TTL_NO_CACHE,
     ): ResponseInterface {
-        if (!str_starts_with($uri, 'http')) {
+        if (str_starts_with($uri, '/')) {
             $uri = $this->apiUri . $uri;
         }
         $headers += $this->authenticator->getAuthorizationHeader() + [


### PR DESCRIPTION
https://myparcelcombv.atlassian.net/browse/MP-7562
---
Replace the full URL comparison when prepending the URL to avoid side effects when the protocol is different.