### PR TITLE
♿️ Add city filter to `getPickUpDropOffLocations()` function

### DIFF
--- a/src/MyParcelComApi.php
+++ b/src/MyParcelComApi.php
@@ -158,6 +158,7 @@ class MyParcelComApi implements MyParcelComApiInterface
         bool $onlyActiveContracts = true,
         int $ttl = self::TTL_10MIN,
         ?array $filters = null,
+        ?string $city = null,
     ): ResourceCollectionInterface|array {
         $carriers = $this->determineCarriersForPudoLocations($onlyActiveContracts, $specificCarrier);
 
@@ -181,6 +182,9 @@ class MyParcelComApi implements MyParcelComApiInterface
         }
         if ($streetNumber) {
             $uri->addQuery(['street_number' => $streetNumber]);
+        }
+        if ($city) {
+            $uri->addQuery(['city' => $city]);
         }
         if ($filters) {
             $uri->addQuery($this->arrayToFilters($filters));


### PR DESCRIPTION
https://api-specification.myparcel.com/#tag/Carriers/paths/~1carriers~1%7Bcarrier_id%7D~1pickup-dropoff-locations~1%7Bcountry_code%7D~1%7Bpostal_code%7D/get
---
Our endpoint supports `street`, `street_number` and `city` as optional query parameters. The SDK should do the same.