### PR TITLE
Add locationType functions to PickUpDropOffLocationInterface

### DIFF
--- a/src/Resources/Interfaces/PickUpDropOffLocationInterface.php
+++ b/src/Resources/Interfaces/PickUpDropOffLocationInterface.php
@@ -43,4 +43,8 @@ interface PickUpDropOffLocationInterface extends ResourceInterface
     public function setCategories(array $categories): self;
 
     public function getCategories(): array;
+
+    public function setLocationType(string $type): self;
+
+    public function getLocationType(): string;
 }


### PR DESCRIPTION
While working with the pick-up and drop off locations I noticed there were 2 functions missing from the `PickUpDropOffLocationInterface`, which are present in the `PickUpDropOffLocation` implementation: `setLocationType` and `getLocationType`. This PR adds those functions to the interface.