### PR TITLE
✨ Added support for collection meta on shipment resource

### DIFF
--- a/src/MyParcelComApi.php
+++ b/src/MyParcelComApi.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MyParcelCom\ApiSdk;
 
-use DateMalformedStringException;
 use DateTimeImmutable;
 use DateTimeInterface;
 use GuzzleHttp\Psr7\Message;
@@ -1004,7 +1003,6 @@ class MyParcelComApi implements MyParcelComApiInterface
      * @return list<array{ date_from: DateTimeImmutable, date_to: DateTimeImmutable }>
      * @throws RequestException
      * @throws JsonException
-     * @throws DateMalformedStringException
      */
     public function getDeliveryDates(
         string $carrierCode,

--- a/src/MyParcelComApiInterface.php
+++ b/src/MyParcelComApiInterface.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MyParcelCom\ApiSdk;
 
-use DateMalformedStringException;
 use DateTimeImmutable;
 use DateTimeInterface;
 use JsonException;
@@ -278,7 +277,6 @@ interface MyParcelComApiInterface
      *  }>
      * @throws RequestException
      * @throws JsonException
-     * @throws DateMalformedStringException
      */
     public function getDeliveryDates(
         string $carrierCode,

--- a/src/Resources/Proxy/ShipmentProxy.php
+++ b/src/Resources/Proxy/ShipmentProxy.php
@@ -572,9 +572,33 @@ class ShipmentProxy implements ShipmentInterface, ResourceProxyInterface
         return $this;
     }
 
+    public function setAddToNextCollection(bool $addToNextCollection): self
+    {
+        $this->getResource()->setAddToNextCollection($addToNextCollection);
+
+        return $this;
+    }
+
+    public function setCollectionMeta(
+        DateTime|int|string $from,
+        DateTime|int|string $to,
+        ?string $description = null,
+    ): self {
+        $this->getResource()->setCollectionMeta($from, $to, $description);
+
+        return $this;
+    }
+
     public function setLabelMimeType(string $labelMimeType): self
     {
         $this->getResource()->setLabelMimeType($labelMimeType);
+
+        return $this;
+    }
+
+    public function setLabelSize(string $labelSize): self
+    {
+        $this->getResource()->setLabelSize($labelSize);
 
         return $this;
     }

--- a/src/Resources/Shipment.php
+++ b/src/Resources/Shipment.php
@@ -6,6 +6,7 @@ namespace MyParcelCom\ApiSdk\Resources;
 
 use DateTime;
 use MyParcelCom\ApiSdk\Enums\DimensionUnitEnum;
+use MyParcelCom\ApiSdk\LabelCombinerInterface;
 use MyParcelCom\ApiSdk\Resources\Interfaces\AddressInterface;
 use MyParcelCom\ApiSdk\Resources\Interfaces\CollectionInterface;
 use MyParcelCom\ApiSdk\Resources\Interfaces\ContractInterface;
@@ -74,7 +75,15 @@ class Shipment implements ShipmentInterface
     const RELATIONSHIP_COLLECTION = 'collection';
     const RELATIONSHIP_SHIPMENT_SURCHARGES = 'shipment_surcharges';
 
-    const META_LABEL_MIME_TYPE = 'label_mime_type';
+    const META_COLLECTION = 'collection';
+    const META_COLLECTION_DESCRIPTION = 'description';
+    const META_COLLECTION_TIME = 'collection_time';
+    const META_COLLECTION_TIME_FROM = 'from';
+    const META_COLLECTION_TIME_TO = 'to';
+    const META_ADD_TO_NEXT_COLLECTION = 'add_to_next_collection';
+    const META_LABEL = 'label';
+    const META_LABEL_MIME_TYPE = 'mime_type';
+    const META_LABEL_SIZE = 'size';
     const META_SERVICE_CODE = 'service_code';
 
     const INCLUDES = [
@@ -157,8 +166,13 @@ class Shipment implements ShipmentInterface
     ];
 
     private array $meta = [
-        self::META_LABEL_MIME_TYPE => FileInterface::MIME_TYPE_PDF,
-        self::META_SERVICE_CODE    => null,
+        self::META_COLLECTION             => [],
+        self::META_ADD_TO_NEXT_COLLECTION => false,
+        self::META_LABEL                  => [
+            self::META_LABEL_MIME_TYPE => FileInterface::MIME_TYPE_PDF,
+            self::META_LABEL_SIZE      => LabelCombinerInterface::PAGE_SIZE_A6,
+        ],
+        self::META_SERVICE_CODE           => null,
     ];
 
     /** @var ShipmentStatusInterface[] */
@@ -821,11 +835,47 @@ class Shipment implements ShipmentInterface
     }
 
     /**
+     * Only for POST /shipments used by MyParcelComApi::createShipment()
+     */
+    public function setAddToNextCollection(bool $addToNextCollection): self
+    {
+        $this->meta[self::META_ADD_TO_NEXT_COLLECTION] = $addToNextCollection;
+
+        return $this;
+    }
+
+    /**
+     * Only for POST /registered-shipments used by MyParcelComApi::createAndRegisterShipment()
+     */
+    public function setCollectionMeta(
+        DateTime|int|string $from,
+        DateTime|int|string $to,
+        ?string $description = null,
+    ): self {
+        $this->meta[self::META_COLLECTION] = [
+            self::META_COLLECTION_DESCRIPTION => $description,
+            self::META_COLLECTION_TIME        => [
+                self::META_COLLECTION_TIME_FROM => DateUtils::toTimestamp($from),
+                self::META_COLLECTION_TIME_TO   => DateUtils::toTimestamp($to),
+            ],
+        ];
+
+        return $this;
+    }
+
+    /**
      * Supported values are FileInterface::MIME_TYPE_PDF or FileInterface::MIME_TYPE_ZPL
      */
     public function setLabelMimeType(string $labelMimeType): self
     {
-        $this->meta[self::META_LABEL_MIME_TYPE] = $labelMimeType;
+        $this->meta[self::META_LABEL][self::META_LABEL_MIME_TYPE] = $labelMimeType;
+
+        return $this;
+    }
+
+    public function setLabelSize(string $labelSize): self
+    {
+        $this->meta[self::META_LABEL][self::META_LABEL_SIZE] = $labelSize;
 
         return $this;
     }

--- a/tests/Feature/ResourceFactoryTest.php
+++ b/tests/Feature/ResourceFactoryTest.php
@@ -449,7 +449,11 @@ class ResourceFactoryTest extends TestCase
         $this->assertEquals([
             'type' => 'shipments',
             'meta' => [
-                'label_mime_type' => 'application/pdf',
+                'add_to_next_collection' => false,
+                'label'                  => [
+                    'mime_type' => 'application/pdf',
+                    'size'      => 'A6',
+                ],
             ],
         ], $shipment->jsonSerialize());
     }
@@ -528,7 +532,7 @@ class ResourceFactoryTest extends TestCase
                         'phone_number'         => '+31 (0)234 567 890',
                     ],
                 ],
-                'drop_off_location'      => [
+                'drop_off_location'    => [
                     'code'    => 'ABC345',
                     'address' => [
                         'street_1'             => 'Diagonally',
@@ -557,7 +561,11 @@ class ResourceFactoryTest extends TestCase
                 'files'           => ['data' => [['id' => 'file-id-1', 'type' => 'files']]],
             ],
             'meta'          => [
-                'label_mime_type' => 'application/pdf',
+                'add_to_next_collection' => false,
+                'label'                  => [
+                    'mime_type' => 'application/pdf',
+                    'size'      => 'A6',
+                ],
             ],
         ];
 
@@ -640,7 +648,7 @@ class ResourceFactoryTest extends TestCase
                         'phone_number'         => '+31 (0)234 567 890',
                     ],
                 ],
-                'drop_off_location'      => [
+                'drop_off_location'    => [
                     'code'    => 'ABC345',
                     'address' => [
                         'street_1'             => 'Diagonally',
@@ -725,7 +733,11 @@ class ResourceFactoryTest extends TestCase
                 'files'           => ['data' => [['id' => 'file-id-1', 'type' => 'files']]],
             ],
             'meta'          => [
-                'label_mime_type' => 'application/pdf',
+                'add_to_next_collection' => false,
+                'label'                  => [
+                    'mime_type' => 'application/pdf',
+                    'size'      => 'A6',
+                ],
             ],
         ];
 

--- a/tests/Unit/Resources/ShipmentTest.php
+++ b/tests/Unit/Resources/ShipmentTest.php
@@ -7,6 +7,7 @@ namespace MyParcelCom\ApiSdk\Tests\Unit\Resources;
 use MyParcelCom\ApiSdk\Enums\DimensionUnitEnum;
 use MyParcelCom\ApiSdk\Enums\TaxTypeEnum;
 use MyParcelCom\ApiSdk\Exceptions\MyParcelComException;
+use MyParcelCom\ApiSdk\LabelCombinerInterface;
 use MyParcelCom\ApiSdk\Resources\Interfaces\AddressInterface;
 use MyParcelCom\ApiSdk\Resources\Interfaces\CollectionInterface;
 use MyParcelCom\ApiSdk\Resources\Interfaces\ContractInterface;
@@ -534,15 +535,39 @@ class ShipmentTest extends TestCase
     }
 
     /** @test */
-    public function testLabelMimeType()
+    public function testCollectionMeta()
     {
         $shipment = new Shipment();
 
-        $this->assertEquals(FileInterface::MIME_TYPE_PDF, $shipment->jsonSerialize()['meta']['label_mime_type']);
+        $this->assertNotContains(Shipment::META_COLLECTION, $shipment->jsonSerialize()['meta']);
+
+        $shipment->setCollectionMeta(123, 456, 'desc');
+
+        $this->assertEquals(
+            [
+                'description'     => 'desc',
+                'collection_time' => [
+                    'from' => 123,
+                    'to'   => 456,
+                ],
+            ],
+            $shipment->jsonSerialize()['meta']['collection'],
+        );
+    }
+
+    /** @test */
+    public function testLabel()
+    {
+        $shipment = new Shipment();
+
+        $this->assertEquals(FileInterface::MIME_TYPE_PDF, $shipment->jsonSerialize()['meta']['label']['mime_type']);
+        $this->assertEquals(LabelCombinerInterface::PAGE_SIZE_A6, $shipment->jsonSerialize()['meta']['label']['size']);
 
         $shipment->setLabelMimeType(FileInterface::MIME_TYPE_ZPL);
+        $shipment->setLabelSize(LabelCombinerInterface::PAGE_SIZE_A4);
 
-        $this->assertEquals(FileInterface::MIME_TYPE_ZPL, $shipment->jsonSerialize()['meta']['label_mime_type']);
+        $this->assertEquals(FileInterface::MIME_TYPE_ZPL, $shipment->jsonSerialize()['meta']['label']['mime_type']);
+        $this->assertEquals(LabelCombinerInterface::PAGE_SIZE_A4, $shipment->jsonSerialize()['meta']['label']['size']);
     }
 
     /** @test */
@@ -915,7 +940,7 @@ class ShipmentTest extends TestCase
                         'phone_number'         => '+31 (0)234 567 890',
                     ],
                 ],
-                'drop_off_location'      => [
+                'drop_off_location'    => [
                     'code'    => 'ABC456',
                     'address' => [
                         'street_1'             => 'Diagonally',
@@ -972,7 +997,11 @@ class ShipmentTest extends TestCase
                 'collection'      => ['data' => ['id' => 'collection-id-1', 'type' => 'collections']],
             ],
             'meta'          => [
-                'label_mime_type' => 'application/pdf',
+                'add_to_next_collection' => false,
+                'label'                  => [
+                    'mime_type' => 'application/pdf',
+                    'size'      => 'A6',
+                ],
             ],
         ], $shipment->jsonSerialize());
     }


### PR DESCRIPTION
https://myparcelcombv.atlassian.net/browse/MP-7634
---
Shipments can have `meta` information to influence what collection they will belong to. This PR adds logic to specify this.

I have also refactored `label_mime_type` to `label.mime_type` and removed a PHP 8.3 import only used in a docblock.